### PR TITLE
ECDH-1PU draft4

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The library can handle all standard JOSE algorithms:
   Object Signing and Encryption (JOSE)
 * draft-ietf-cose-webauthn-algorithms-03 - COSE and JOSE Registrations for 
   WebAuthn Algorithms
-
+* draft-madden-jose-ecdh-1pu-04 - Public Key Authenticated Encryption for JOSE: ECDH-1PU
 
 ## System requirements and dependencies
 

--- a/src/main/java/com/nimbusds/jose/JWEAlgorithm.java
+++ b/src/main/java/com/nimbusds/jose/JWEAlgorithm.java
@@ -40,7 +40,7 @@ import net.jcip.annotations.Immutable;
  *     <li>{@link #ECDH_ES_A128KW ESDH-ES+A128KW}
  *     <li>{@link #ECDH_ES_A128KW ESDH-ES+A192KW}
  *     <li>{@link #ECDH_ES_A256KW ESDH-ES+A256KW}
- *     <li>{@link #ECDH_1PU ECDH-ES}
+ *     <li>{@link #ECDH_1PU ECDH-1PU}
  *     <li>{@link #ECDH_1PU_A128KW ESDH-1PU+A128KW}
  *     <li>{@link #ECDH_1PU_A128KW ESDH-1PU+A192KW}
  *     <li>{@link #ECDH_1PU_A256KW ESDH-1PU+A256KW}

--- a/src/main/java/com/nimbusds/jose/JWEAlgorithm.java
+++ b/src/main/java/com/nimbusds/jose/JWEAlgorithm.java
@@ -40,6 +40,10 @@ import net.jcip.annotations.Immutable;
  *     <li>{@link #ECDH_ES_A128KW ESDH-ES+A128KW}
  *     <li>{@link #ECDH_ES_A128KW ESDH-ES+A192KW}
  *     <li>{@link #ECDH_ES_A256KW ESDH-ES+A256KW}
+ *     <li>{@link #ECDH_1PU ECDH-ES}
+ *     <li>{@link #ECDH_1PU_A128KW ESDH-1PU+A128KW}
+ *     <li>{@link #ECDH_1PU_A128KW ESDH-1PU+A192KW}
+ *     <li>{@link #ECDH_1PU_A256KW ESDH-1PU+A256KW}
  *     <li>{@link #PBES2_HS256_A128KW PBES2-HS256+A128KW}
  *     <li>{@link #PBES2_HS384_A192KW PBES2-HS256+A192KW}
  *     <li>{@link #PBES2_HS512_A256KW PBES2-HS256+A256KW}
@@ -148,6 +152,42 @@ public final class JWEAlgorithm extends Algorithm {
 	 */
 	public static final JWEAlgorithm ECDH_ES_A256KW = new JWEAlgorithm("ECDH-ES+A256KW", Requirement.RECOMMENDED);
 
+
+	/**
+	 * Elliptic Curve Diffie-Hellman One-Pass Unified Model key
+	 * agreement using the Concat KDF, as defined in section 5.8.1 of
+	 * NIST.800-56A, with the agreed-upon key being used directly as the
+	 * Content Encryption Key (CEK) (rather than being used to wrap the
+	 * CEK).
+	 */
+	public static final JWEAlgorithm ECDH_1PU = new JWEAlgorithm("ECDH-1PU", Requirement.OPTIONAL);
+
+
+	/**
+	 * Elliptic Curve Diffie-Hellman One-Pass Unified Model key agreement per
+	 * "ECDH-1PU", but where the agreed-upon key is used to wrap the Content
+	 * Encryption Key (CEK) with the "A128KW" function (rather than being
+	 * used directly as the CEK).
+	 */
+	public static final JWEAlgorithm ECDH_1PU_A128KW = new JWEAlgorithm("ECDH-1PU+A128KW", Requirement.OPTIONAL);
+
+
+	/**
+	 * Elliptic Curve Diffie-Hellman One-Pass Unified Model key agreement per
+	 * "ECDH-1PU", but where the agreed-upon key is used to wrap the Content
+	 * Encryption Key (CEK) with the "A192KW" function (rather than being
+	 * used directly as the CEK).
+	 */
+	public static final JWEAlgorithm ECDH_1PU_A192KW = new JWEAlgorithm("ECDH-1PU+A192KW", Requirement.OPTIONAL);
+
+
+	/**
+	 * Elliptic Curve Diffie-Hellman One-Pass Unified Model key agreement per
+	 * "ECDH-1PU", but where the agreed-upon key is used to wrap the Content
+	 * Encryption Key (CEK) with the "A256KW" function (rather than being
+	 * used directly as the CEK).
+	 */
+	public static final JWEAlgorithm ECDH_1PU_A256KW = new JWEAlgorithm("ECDH-1PU+A256KW", Requirement.OPTIONAL);
 
 	/**
 	 * AES in Galois/Counter Mode (GCM) (NIST.800-38D) 128 bit keys.

--- a/src/main/java/com/nimbusds/jose/crypto/ECDH1PUDecrypter.java
+++ b/src/main/java/com/nimbusds/jose/crypto/ECDH1PUDecrypter.java
@@ -1,0 +1,285 @@
+/*
+ * nimbus-jose-jwt
+ *
+ * Copyright 2012-2016, Connect2id Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.nimbusds.jose.crypto;
+
+
+import com.nimbusds.jose.CriticalHeaderParamsAware;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEDecrypter;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.crypto.impl.*;
+import com.nimbusds.jose.crypto.utils.ECChecks;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.util.Base64URL;
+
+import javax.crypto.SecretKey;
+import java.security.PrivateKey;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+
+/**
+ * Elliptic Curve Diffie-Hellman decrypter of
+ * {@link com.nimbusds.jose.JWEObject JWE objects} for curves using EC JWK
+ * keys. Expects a private EC key (with a P-256, P-384 or P-521 curve).
+ *
+ * <p>Public Key Authenticated Encryption for JOSE
+ * <a href="https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04">ECDH-1PU</a>
+ * for more information.
+ *
+ * <p>For Curve25519/X25519, see {@link ECDH1PUX25519Decrypter} instead.
+ *
+ * <p>This class is thread-safe.
+ *
+ * <p>Supports the following key management algorithms:
+ *
+ * <ul>
+ *     <li>{@link com.nimbusds.jose.JWEAlgorithm#ECDH_1PU}
+ *     <li>{@link com.nimbusds.jose.JWEAlgorithm#ECDH_1PU_A128KW}
+ *     <li>{@link com.nimbusds.jose.JWEAlgorithm#ECDH_1PU_A192KW}
+ *     <li>{@link com.nimbusds.jose.JWEAlgorithm#ECDH_1PU_A256KW}
+ * </ul>
+ *
+ * <p>Supports the following elliptic curves:
+ *
+ * <ul>
+ *     <li>{@link Curve#P_256}
+ *     <li>{@link Curve#P_384}
+ *     <li>{@link Curve#P_521}
+ * </ul>
+ *
+ * <p>Supports the following content encryption algorithms for Direct key agreement mode:
+ *
+ * <ul>
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A192CBC_HS384}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128GCM}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A192GCM}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256GCM}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256_DEPRECATED}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512_DEPRECATED}
+ * </ul>
+ *
+ * <p>Supports the following content encryption algorithms for Direct Key wrapping mode:
+ *
+ * <ul>
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A192CBC_HS384}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512}
+ * </ul>
+ *
+ * @author Alexander Martynov
+ * @version 2021-08-03
+ */
+public class ECDH1PUDecrypter extends ECDH1PUCryptoProvider implements JWEDecrypter, CriticalHeaderParamsAware {
+
+
+	/**
+	 * The supported EC JWK curves by the ECDH crypto provider class.
+	 */
+	public static final Set<Curve> SUPPORTED_ELLIPTIC_CURVES;
+
+
+	static {
+		Set<Curve> curves = new LinkedHashSet<>();
+		curves.add(Curve.P_256);
+		curves.add(Curve.P_384);
+		curves.add(Curve.P_521);
+		SUPPORTED_ELLIPTIC_CURVES = Collections.unmodifiableSet(curves);
+	}
+
+
+	/**
+	 * The private EC key.
+	 */
+	private final PrivateKey privateKey;
+
+	/**
+	 * The public EC key.
+	 */
+	private final ECPublicKey publicKey;
+
+	/**
+	 * The critical header policy.
+	 */
+	private final CriticalHeaderParamsDeferral critPolicy = new CriticalHeaderParamsDeferral();
+
+
+	/**
+	 * Creates a new Elliptic Curve Diffie-Hellman decrypter.
+	 *
+	 * @param privateKey 	The private EC key. Must not be {@code null}.
+	 * @param publicKey 	The public EC key. Must not be {@code null}.
+	 *
+	 * @throws JOSEException If the elliptic curve is not supported.
+	 */
+	public ECDH1PUDecrypter(final ECPrivateKey privateKey,
+							final ECPublicKey publicKey)
+		throws JOSEException {
+
+		this(privateKey, publicKey, (Set<String>) null);
+	}
+
+	/**
+	 * Creates a new Elliptic Curve Diffie-Hellman decrypter.
+	 *
+	 * @param privateKey     The private EC key. Must not be {@code null}.
+	 * @param publicKey 	 The public EC key. Must not be {@code null}.
+	 * @param defCritHeaders The names of the critical header parameters
+	 *                       that are deferred to the application for
+	 *                       processing, empty set or {@code null} if none.
+	 *
+	 * @throws JOSEException If the elliptic curve is not supported.
+	 */
+	public ECDH1PUDecrypter(final ECPrivateKey privateKey,
+							final ECPublicKey publicKey,
+							final Set<String> defCritHeaders)
+		throws JOSEException {
+
+		this(privateKey, publicKey, defCritHeaders, Curve.forECParameterSpec(privateKey.getParams()));
+	}
+
+
+	/**
+	 * Creates a new Elliptic Curve Diffie-Hellman decrypter. This
+	 * constructor can also accept a private EC key located in a PKCS#11
+	 * store that doesn't expose the private key parameters (such as a
+	 * smart card or HSM).
+	 *
+	 * @param privateKey     The private EC key. Must not be {@code null}.
+	 * @param publicKey 	 The public EC key. Must not be {@code null}.
+	 * @param defCritHeaders The names of the critical header parameters
+	 *                       that are deferred to the application for
+	 *                       processing, empty set or {@code null} if none.
+	 * @param curve          The key curve. Must not be {@code null}.
+	 *
+	 * @throws JOSEException If the elliptic curve is not supported.
+	 */
+	public ECDH1PUDecrypter(final ECPrivateKey privateKey,
+							final ECPublicKey publicKey,
+                            final Set<String> defCritHeaders,
+                            final Curve curve)
+		throws JOSEException {
+
+		super(curve);
+
+		critPolicy.setDeferredCriticalHeaderParams(defCritHeaders);
+
+		this.privateKey = privateKey;
+		this.publicKey = publicKey;
+	}
+
+	/**
+	 * Returns the public EC key.
+	 *
+	 * @return The public EC key.
+	 */
+	public ECPublicKey getPublicKey() {
+
+		return publicKey;
+	}
+
+	/**
+	 * Returns the private EC key.
+	 *
+	 * @return The private EC key. Casting to
+	 *         {@link ECPrivateKey} may not be
+	 *         possible if the key is located in a PKCS#11 store that
+	 *         doesn't expose the private key parameters.
+	 */
+	public PrivateKey getPrivateKey() {
+
+		return privateKey;
+	}
+
+
+	@Override
+	public Set<Curve> supportedEllipticCurves() {
+
+		return SUPPORTED_ELLIPTIC_CURVES;
+	}
+
+
+	@Override
+	public Set<String> getProcessedCriticalHeaderParams() {
+
+		return critPolicy.getProcessedCriticalHeaderParams();
+	}
+
+
+	@Override
+	public Set<String> getDeferredCriticalHeaderParams() {
+
+		return critPolicy.getProcessedCriticalHeaderParams();
+	}
+
+
+	@Override
+	public byte[] decrypt(final JWEHeader header,
+			      final Base64URL encryptedKey,
+			      final Base64URL iv,
+			      final Base64URL cipherText,
+			      final Base64URL authTag)
+		throws JOSEException {
+
+		critPolicy.ensureHeaderPasses(header);
+
+		// Get ephemeral EC key
+		ECKey ephemeralKey = (ECKey) header.getEphemeralPublicKey();
+
+		if (ephemeralKey == null) {
+			throw new JOSEException("Missing ephemeral public EC key \"epk\" JWE header parameter");
+		}
+
+		ECPublicKey ephemeralPublicKey = ephemeralKey.toECPublicKey();
+		
+		// Curve check
+		if (getPrivateKey() instanceof ECPrivateKey) {
+			ECPrivateKey ecPrivateKey = (ECPrivateKey)getPrivateKey();
+			if (!ECChecks.isPointOnCurve(ephemeralPublicKey, ecPrivateKey)) {
+				throw new JOSEException("Invalid ephemeral public EC key: Point(s) not on the expected curve");
+			}
+		} else {
+			if (!ECChecks.isPointOnCurve(ephemeralPublicKey, getCurve().toECParameterSpec())) {
+				throw new JOSEException("Invalid ephemeral public EC key: Point(s) not on the expected curve");
+			}
+		}
+
+		// Derive 'Ze'
+		SecretKey Ze = ECDH.deriveSharedSecret(
+			ephemeralPublicKey,
+			privateKey,
+			getJCAContext().getKeyEncryptionProvider());
+
+		// Derive Zs
+		SecretKey Zs = ECDH.deriveSharedSecret(
+				publicKey,
+				privateKey,
+				getJCAContext().getKeyEncryptionProvider());
+
+		// Derive 'Z'
+		SecretKey Z = ECDH1PU.deriveZ(Ze, Zs);
+
+		return decryptWithZ(header, Z, encryptedKey, iv, cipherText, authTag);
+	}
+}

--- a/src/main/java/com/nimbusds/jose/crypto/ECDH1PUDecrypter.java
+++ b/src/main/java/com/nimbusds/jose/crypto/ECDH1PUDecrypter.java
@@ -95,181 +95,181 @@ import java.util.Set;
 public class ECDH1PUDecrypter extends ECDH1PUCryptoProvider implements JWEDecrypter, CriticalHeaderParamsAware {
 
 
-	/**
-	 * The supported EC JWK curves by the ECDH crypto provider class.
-	 */
-	public static final Set<Curve> SUPPORTED_ELLIPTIC_CURVES;
+    /**
+     * The supported EC JWK curves by the ECDH crypto provider class.
+     */
+    public static final Set<Curve> SUPPORTED_ELLIPTIC_CURVES;
 
 
-	static {
-		Set<Curve> curves = new LinkedHashSet<>();
-		curves.add(Curve.P_256);
-		curves.add(Curve.P_384);
-		curves.add(Curve.P_521);
-		SUPPORTED_ELLIPTIC_CURVES = Collections.unmodifiableSet(curves);
-	}
+    static {
+        Set<Curve> curves = new LinkedHashSet<>();
+        curves.add(Curve.P_256);
+        curves.add(Curve.P_384);
+        curves.add(Curve.P_521);
+        SUPPORTED_ELLIPTIC_CURVES = Collections.unmodifiableSet(curves);
+    }
 
 
-	/**
-	 * The private EC key.
-	 */
-	private final ECPrivateKey privateKey;
+    /**
+     * The private EC key.
+     */
+    private final ECPrivateKey privateKey;
 
-	/**
-	 * The public EC key.
-	 */
-	private final ECPublicKey publicKey;
+    /**
+     * The public EC key.
+     */
+    private final ECPublicKey publicKey;
 
-	/**
-	 * The critical header policy.
-	 */
-	private final CriticalHeaderParamsDeferral critPolicy = new CriticalHeaderParamsDeferral();
-
-
-	/**
-	 * Creates a new Elliptic Curve Diffie-Hellman decrypter.
-	 *
-	 * @param privateKey 	The private EC key. Must not be {@code null}.
-	 * @param publicKey 	The public EC key. Must not be {@code null}.
-	 *
-	 * @throws JOSEException If the elliptic curve is not supported.
-	 */
-	public ECDH1PUDecrypter(final ECPrivateKey privateKey,
-							final ECPublicKey publicKey)
-		throws JOSEException {
-
-		this(privateKey, publicKey, null);
-	}
-
-	/**
-	 * Creates a new Elliptic Curve Diffie-Hellman decrypter.
-	 *
-	 * @param privateKey     The private EC key. Must not be {@code null}.
-	 * @param publicKey 	 The public EC key. Must not be {@code null}.
-	 * @param defCritHeaders The names of the critical header parameters
-	 *                       that are deferred to the application for
-	 *                       processing, empty set or {@code null} if none.
-	 *
-	 * @throws JOSEException If the elliptic curve is not supported.
-	 */
-	public ECDH1PUDecrypter(final ECPrivateKey privateKey,
-							final ECPublicKey publicKey,
-							final Set<String> defCritHeaders)
-		throws JOSEException {
-
-		this(privateKey, publicKey, defCritHeaders, Curve.forECParameterSpec(privateKey.getParams()));
-	}
+    /**
+     * The critical header policy.
+     */
+    private final CriticalHeaderParamsDeferral critPolicy = new CriticalHeaderParamsDeferral();
 
 
-	/**
-	 * Creates a new Elliptic Curve Diffie-Hellman decrypter. This
-	 * constructor can also accept a private EC key located in a PKCS#11
-	 * store that doesn't expose the private key parameters (such as a
-	 * smart card or HSM).
-	 *
-	 * @param privateKey     The private EC key. Must not be {@code null}.
-	 * @param publicKey 	 The public EC key. Must not be {@code null}.
-	 * @param defCritHeaders The names of the critical header parameters
-	 *                       that are deferred to the application for
-	 *                       processing, empty set or {@code null} if none.
-	 * @param curve          The key curve. Must not be {@code null}.
-	 *
-	 * @throws JOSEException If the elliptic curve is not supported.
-	 */
-	public ECDH1PUDecrypter(final ECPrivateKey privateKey,
-							final ECPublicKey publicKey,
+    /**
+     * Creates a new Elliptic Curve Diffie-Hellman decrypter.
+     *
+     * @param privateKey 	The private EC key. Must not be {@code null}.
+     * @param publicKey 	The public EC key. Must not be {@code null}.
+     *
+     * @throws JOSEException If the elliptic curve is not supported.
+     */
+    public ECDH1PUDecrypter(final ECPrivateKey privateKey,
+                            final ECPublicKey publicKey)
+        throws JOSEException {
+
+        this(privateKey, publicKey, null);
+    }
+
+    /**
+     * Creates a new Elliptic Curve Diffie-Hellman decrypter.
+     *
+     * @param privateKey     The private EC key. Must not be {@code null}.
+     * @param publicKey 	 The public EC key. Must not be {@code null}.
+     * @param defCritHeaders The names of the critical header parameters
+     *                       that are deferred to the application for
+     *                       processing, empty set or {@code null} if none.
+     *
+     * @throws JOSEException If the elliptic curve is not supported.
+     */
+    public ECDH1PUDecrypter(final ECPrivateKey privateKey,
+                            final ECPublicKey publicKey,
+                            final Set<String> defCritHeaders)
+        throws JOSEException {
+
+        this(privateKey, publicKey, defCritHeaders, Curve.forECParameterSpec(privateKey.getParams()));
+    }
+
+
+    /**
+     * Creates a new Elliptic Curve Diffie-Hellman decrypter. This
+     * constructor can also accept a private EC key located in a PKCS#11
+     * store that doesn't expose the private key parameters (such as a
+     * smart card or HSM).
+     *
+     * @param privateKey     The private EC key. Must not be {@code null}.
+     * @param publicKey 	 The public EC key. Must not be {@code null}.
+     * @param defCritHeaders The names of the critical header parameters
+     *                       that are deferred to the application for
+     *                       processing, empty set or {@code null} if none.
+     * @param curve          The key curve. Must not be {@code null}.
+     *
+     * @throws JOSEException If the elliptic curve is not supported.
+     */
+    public ECDH1PUDecrypter(final ECPrivateKey privateKey,
+                            final ECPublicKey publicKey,
                             final Set<String> defCritHeaders,
                             final Curve curve)
-		throws JOSEException {
+        throws JOSEException {
 
-		super(curve);
+        super(curve);
 
-		critPolicy.setDeferredCriticalHeaderParams(defCritHeaders);
+        critPolicy.setDeferredCriticalHeaderParams(defCritHeaders);
 
-		this.privateKey = privateKey;
-		this.publicKey = publicKey;
-	}
+        this.privateKey = privateKey;
+        this.publicKey = publicKey;
+    }
 
-	/**
-	 * Returns the public EC key.
-	 *
-	 * @return The public EC key.
-	 */
-	public ECPublicKey getPublicKey() {
+    /**
+     * Returns the public EC key.
+     *
+     * @return The public EC key.
+     */
+    public ECPublicKey getPublicKey() {
 
-		return publicKey;
-	}
+        return publicKey;
+    }
 
-	/**
-	 * Returns the private EC key.
-	 *
-	 * @return The private EC key. Casting to
-	 *         {@link ECPrivateKey} may not be
-	 *         possible if the key is located in a PKCS#11 store that
-	 *         doesn't expose the private key parameters.
-	 */
-	public PrivateKey getPrivateKey() {
+    /**
+     * Returns the private EC key.
+     *
+     * @return The private EC key. Casting to
+     *         {@link ECPrivateKey} may not be
+     *         possible if the key is located in a PKCS#11 store that
+     *         doesn't expose the private key parameters.
+     */
+    public PrivateKey getPrivateKey() {
 
-		return privateKey;
-	}
-
-
-	@Override
-	public Set<Curve> supportedEllipticCurves() {
-
-		return SUPPORTED_ELLIPTIC_CURVES;
-	}
+        return privateKey;
+    }
 
 
-	@Override
-	public Set<String> getProcessedCriticalHeaderParams() {
+    @Override
+    public Set<Curve> supportedEllipticCurves() {
 
-		return critPolicy.getProcessedCriticalHeaderParams();
-	}
-
-
-	@Override
-	public Set<String> getDeferredCriticalHeaderParams() {
-
-		return critPolicy.getProcessedCriticalHeaderParams();
-	}
+        return SUPPORTED_ELLIPTIC_CURVES;
+    }
 
 
-	@Override
-	public byte[] decrypt(final JWEHeader header,
-			      final Base64URL encryptedKey,
-			      final Base64URL iv,
-			      final Base64URL cipherText,
-			      final Base64URL authTag)
-		throws JOSEException {
+    @Override
+    public Set<String> getProcessedCriticalHeaderParams() {
 
-		ECDH1PU.validateSameCurve(privateKey, publicKey);
+        return critPolicy.getProcessedCriticalHeaderParams();
+    }
 
-		critPolicy.ensureHeaderPasses(header);
 
-		// Get ephemeral EC key
-		ECKey ephemeralKey = (ECKey) header.getEphemeralPublicKey();
+    @Override
+    public Set<String> getDeferredCriticalHeaderParams() {
 
-		if (ephemeralKey == null) {
-			throw new JOSEException("Missing ephemeral public EC key \"epk\" JWE header parameter");
-		}
+        return critPolicy.getProcessedCriticalHeaderParams();
+    }
 
-		ECPublicKey ephemeralPublicKey = ephemeralKey.toECPublicKey();
 
-		ECDH1PU.validateSameCurve(privateKey, ephemeralPublicKey);
+    @Override
+    public byte[] decrypt(final JWEHeader header,
+                  final Base64URL encryptedKey,
+                  final Base64URL iv,
+                  final Base64URL cipherText,
+                  final Base64URL authTag)
+        throws JOSEException {
 
-		SecretKey Ze = ECDH.deriveSharedSecret(
-			ephemeralPublicKey,
-			privateKey,
-			getJCAContext().getKeyEncryptionProvider());
+        ECDH1PU.validateSameCurve(privateKey, publicKey);
 
-		SecretKey Zs = ECDH.deriveSharedSecret(
-				publicKey,
-				privateKey,
-				getJCAContext().getKeyEncryptionProvider());
+        critPolicy.ensureHeaderPasses(header);
 
-		SecretKey Z = ECDH1PU.deriveZ(Ze, Zs);
+        // Get ephemeral EC key
+        ECKey ephemeralKey = (ECKey) header.getEphemeralPublicKey();
 
-		return decryptWithZ(header, Z, encryptedKey, iv, cipherText, authTag);
-	}
+        if (ephemeralKey == null) {
+            throw new JOSEException("Missing ephemeral public EC key \"epk\" JWE header parameter");
+        }
+
+        ECPublicKey ephemeralPublicKey = ephemeralKey.toECPublicKey();
+
+        ECDH1PU.validateSameCurve(privateKey, ephemeralPublicKey);
+
+        SecretKey Ze = ECDH.deriveSharedSecret(
+            ephemeralPublicKey,
+            privateKey,
+            getJCAContext().getKeyEncryptionProvider());
+
+        SecretKey Zs = ECDH.deriveSharedSecret(
+                publicKey,
+                privateKey,
+                getJCAContext().getKeyEncryptionProvider());
+
+        SecretKey Z = ECDH1PU.deriveZ(Ze, Zs);
+
+        return decryptWithZ(header, Z, encryptedKey, iv, cipherText, authTag);
+    }
 }

--- a/src/main/java/com/nimbusds/jose/crypto/ECDH1PUDecrypter.java
+++ b/src/main/java/com/nimbusds/jose/crypto/ECDH1PUDecrypter.java
@@ -134,8 +134,7 @@ public class ECDH1PUDecrypter extends ECDH1PUCryptoProvider implements JWEDecryp
      *
      * @throws JOSEException If the elliptic curve is not supported.
      */
-    public ECDH1PUDecrypter(final ECPrivateKey privateKey,
-                            final ECPublicKey publicKey)
+    public ECDH1PUDecrypter(final ECPrivateKey privateKey, final ECPublicKey publicKey)
         throws JOSEException {
 
         this(privateKey, publicKey, null);
@@ -237,10 +236,10 @@ public class ECDH1PUDecrypter extends ECDH1PUCryptoProvider implements JWEDecryp
 
     @Override
     public byte[] decrypt(final JWEHeader header,
-                  final Base64URL encryptedKey,
-                  final Base64URL iv,
-                  final Base64URL cipherText,
-                  final Base64URL authTag)
+                          final Base64URL encryptedKey,
+                          final Base64URL iv,
+                          final Base64URL cipherText,
+                          final Base64URL authTag)
         throws JOSEException {
 
         ECDH1PU.validateSameCurve(privateKey, publicKey);

--- a/src/main/java/com/nimbusds/jose/crypto/ECDH1PUDecrypter.java
+++ b/src/main/java/com/nimbusds/jose/crypto/ECDH1PUDecrypter.java
@@ -1,7 +1,7 @@
 /*
  * nimbus-jose-jwt
  *
- * Copyright 2012-2021, Connect2id Ltd.
+ * Copyright 2012-2021, Connect2id Ltd and contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy of the
@@ -23,7 +23,6 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWEDecrypter;
 import com.nimbusds.jose.JWEHeader;
 import com.nimbusds.jose.crypto.impl.*;
-import com.nimbusds.jose.crypto.utils.ECChecks;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.util.Base64URL;
@@ -81,7 +80,7 @@ import java.util.Set;
  *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512_DEPRECATED}
  * </ul>
  *
- * <p>Supports the following content encryption algorithms for Direct Key wrapping mode:
+ * <p>Supports the following content encryption algorithms for Key wrapping mode:
  *
  * <ul>
  *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256}
@@ -256,18 +255,8 @@ public class ECDH1PUDecrypter extends ECDH1PUCryptoProvider implements JWEDecryp
 		}
 
 		ECPublicKey ephemeralPublicKey = ephemeralKey.toECPublicKey();
-		
-		// Curve check
-		if (getPrivateKey() instanceof ECPrivateKey) {
-			ECPrivateKey ecPrivateKey = (ECPrivateKey)getPrivateKey();
-			if (!ECChecks.isPointOnCurve(ephemeralPublicKey, ecPrivateKey)) {
-				throw new JOSEException("Invalid ephemeral public EC key: Point(s) not on the expected curve");
-			}
-		} else {
-			if (!ECChecks.isPointOnCurve(ephemeralPublicKey, getCurve().toECParameterSpec())) {
-				throw new JOSEException("Invalid ephemeral public EC key: Point(s) not on the expected curve");
-			}
-		}
+
+		ECDH1PU.validateSameCurve(privateKey, ephemeralPublicKey);
 
 		SecretKey Ze = ECDH.deriveSharedSecret(
 			ephemeralPublicKey,

--- a/src/main/java/com/nimbusds/jose/crypto/ECDH1PUEncrypter.java
+++ b/src/main/java/com/nimbusds/jose/crypto/ECDH1PUEncrypter.java
@@ -1,0 +1,275 @@
+/*
+ * nimbus-jose-jwt
+ *
+ * Copyright 2012-2019, Connect2id Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.nimbusds.jose.crypto;
+
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWECryptoParts;
+import com.nimbusds.jose.JWEEncrypter;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.crypto.impl.ECDH;
+import com.nimbusds.jose.crypto.impl.ECDH1PU;
+import com.nimbusds.jose.crypto.impl.ECDH1PUCryptoProvider;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import net.jcip.annotations.ThreadSafe;
+
+import javax.crypto.SecretKey;
+import java.security.*;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+
+/**
+ * Elliptic Curve Diffie-Hellman encrypter of
+ * {@link com.nimbusds.jose.JWEObject JWE objects} for curves using EC JWK keys.
+ * Expects a public EC key (with a P-256, P-384, or P-521 curve).
+ *
+ * <p>Public Key Authenticated Encryption for JOSE
+ * <a href="https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04">ECDH-1PU</a>
+ * for more information.
+ *
+ * <p>For Curve25519/X25519, see {@link ECDH1PUX25519Encrypter} instead.
+ *
+ * <p>This class is thread-safe.
+ *
+ * <p>Supports the following key management algorithms:
+ *
+ * <ul>
+ *     <li>{@link com.nimbusds.jose.JWEAlgorithm#ECDH_1PU}
+ *     <li>{@link com.nimbusds.jose.JWEAlgorithm#ECDH_1PU_A128KW}
+ *     <li>{@link com.nimbusds.jose.JWEAlgorithm#ECDH_1PU_A192KW}
+ *     <li>{@link com.nimbusds.jose.JWEAlgorithm#ECDH_1PU_A256KW}
+ * </ul>
+ *
+ * <p>Supports the following elliptic curves:
+ *
+ * <ul>
+ *     <li>{@link Curve#P_256}
+ *     <li>{@link Curve#P_384}
+ *     <li>{@link Curve#P_521}
+ * </ul>
+ *
+ * <p>Supports the following content encryption algorithms for Direct key agreement mode:
+ *
+ * <ul>
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A192CBC_HS384}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128GCM}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A192GCM}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256GCM}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256_DEPRECATED}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512_DEPRECATED}
+ * </ul>
+ *
+ * <p>Supports the following content encryption algorithms for Direct Key wrapping mode:
+ *
+ * <ul>
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A192CBC_HS384}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512}
+ * </ul>
+ *
+ * @author Alexander Martynov
+ * @version 2021-08-03
+ */
+@ThreadSafe
+public class ECDH1PUEncrypter extends ECDH1PUCryptoProvider implements JWEEncrypter {
+
+
+	/**
+	 * The supported EC JWK curves by the ECDH crypto provider class.
+	 */
+	public static final Set<Curve> SUPPORTED_ELLIPTIC_CURVES;
+
+
+	static {
+		Set<Curve> curves = new LinkedHashSet<>();
+		curves.add(Curve.P_256);
+		curves.add(Curve.P_384);
+		curves.add(Curve.P_521);
+		SUPPORTED_ELLIPTIC_CURVES = Collections.unmodifiableSet(curves);
+	}
+
+
+	/**
+	 * The public JWK key.
+	 */
+	private final ECPublicKey publicKey;
+
+	/**
+	 * The private JWK key;
+	 */
+	private final ECPrivateKey privateKey;
+
+	/**
+	 * The externally supplied AES content encryption key (CEK) to use,
+	 * {@code null} to generate a CEK for each JWE.
+	 */
+	private final SecretKey contentEncryptionKey;
+
+	/**
+	 * Creates a new Elliptic Curve Diffie-Hellman encrypter.
+	 *
+	 * @param privateKey The private EC key. Must not be {@code null}.
+	 *
+	 * @param publicKey The public EC key. Must not be {@code null}.
+	 *
+	 * @throws JOSEException If the elliptic curve is not supported.
+	 */
+	public ECDH1PUEncrypter(final ECPrivateKey privateKey, final ECPublicKey publicKey)
+		throws JOSEException {
+
+		this(privateKey, publicKey, null);
+	}
+
+
+	/**
+	 * Creates a new Elliptic Curve Diffie-Hellman encrypter with an
+	 * optionally specified content encryption key (CEK).
+	 *
+	 * @param privateKey            The private EC key. Must not be
+	 *               			   {@code null}.
+	 *
+	 * @param publicKey            The public EC key. Must not be
+	 *                             {@code null}.
+	 * @param contentEncryptionKey The content encryption key (CEK) to use.
+	 *                             If specified its algorithm must be "AES"
+	 *                             and its length must match the expected
+	 *                             for the JWE encryption method ("enc").
+	 *                             If {@code null} a CEK will be generated
+	 *                             for each JWE.
+	 * @throws JOSEException       If the elliptic curve is not supported.
+	 */
+	public ECDH1PUEncrypter(final ECPrivateKey privateKey, final ECPublicKey publicKey, final SecretKey contentEncryptionKey)
+		throws JOSEException {
+
+		super(Curve.forECParameterSpec(publicKey.getParams()));
+
+		this.privateKey = privateKey;
+		this.publicKey = publicKey;
+
+		if (contentEncryptionKey != null) {
+			if (contentEncryptionKey.getAlgorithm() == null || !contentEncryptionKey.getAlgorithm().equals("AES")) {
+				throw new IllegalArgumentException("The algorithm of the content encryption key (CEK) must be AES");
+			} else {
+				this.contentEncryptionKey = contentEncryptionKey;
+			}
+		} else {
+			this.contentEncryptionKey = null;
+		}
+	}
+
+
+	/**
+	 * Returns the public EC key.
+	 *
+	 * @return The public EC key.
+	 */
+	public ECPublicKey getPublicKey() {
+
+		return publicKey;
+	}
+
+
+	/**
+	 * Returns the private EC key.
+	 *
+	 * @return The private EC key.
+	 */
+	public ECPrivateKey getPrivateKey() {
+
+		return privateKey;
+	}
+
+
+	@Override
+	public Set<Curve> supportedEllipticCurves() {
+
+		return SUPPORTED_ELLIPTIC_CURVES;
+	}
+
+
+	@Override
+	public JWECryptoParts encrypt(final JWEHeader header, final byte[] clearText)
+		throws JOSEException {
+
+		// Generate ephemeral EC key pair on the same curve as the consumer's public key
+		KeyPair ephemeralKeyPair = generateEphemeralKeyPair(publicKey.getParams());
+		ECPublicKey ephemeralPublicKey = (ECPublicKey)ephemeralKeyPair.getPublic();
+		ECPrivateKey ephemeralPrivateKey = (ECPrivateKey)ephemeralKeyPair.getPrivate();
+
+		// Add the ephemeral public EC key to the header
+		JWEHeader updatedHeader = new JWEHeader.Builder(header).
+			ephemeralPublicKey(new ECKey.Builder(getCurve(), ephemeralPublicKey).build()).
+			build();
+
+		// Derive 'Ze'
+		SecretKey Ze = ECDH.deriveSharedSecret(
+			publicKey,
+			ephemeralPrivateKey,
+			getJCAContext().getKeyEncryptionProvider());
+
+		// Derive 'Zs'
+		SecretKey Zs = ECDH.deriveSharedSecret(
+				publicKey,
+				privateKey,
+				getJCAContext().getKeyEncryptionProvider());
+
+		// Derive 'Z'
+		SecretKey Z = ECDH1PU.deriveZ(Ze, Zs);
+
+		return encryptWithZ(updatedHeader, Z, clearText, contentEncryptionKey);
+	}
+
+
+	/**
+	 * Generates a new ephemeral EC key pair with the specified curve.
+	 *
+	 * @param ecParameterSpec The EC key spec. Must not be {@code null}.
+	 *
+	 * @return The EC key pair.
+	 *
+	 * @throws JOSEException If the EC key pair couldn't be generated.
+	 */
+	private KeyPair generateEphemeralKeyPair(final ECParameterSpec ecParameterSpec)
+		throws JOSEException {
+
+		Provider keProvider = getJCAContext().getKeyEncryptionProvider();
+
+		try {
+			KeyPairGenerator generator;
+
+			if (keProvider != null) {
+				generator = KeyPairGenerator.getInstance("EC", keProvider);
+			} else {
+				generator = KeyPairGenerator.getInstance("EC");
+			}
+
+			generator.initialize(ecParameterSpec);
+			return generator.generateKeyPair();
+		} catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException e) {
+			throw new JOSEException("Couldn't generate ephemeral EC key pair: " + e.getMessage(), e);
+		}
+	}
+}

--- a/src/main/java/com/nimbusds/jose/crypto/ECDH1PUEncrypter.java
+++ b/src/main/java/com/nimbusds/jose/crypto/ECDH1PUEncrypter.java
@@ -97,175 +97,175 @@ import java.util.Set;
 public class ECDH1PUEncrypter extends ECDH1PUCryptoProvider implements JWEEncrypter {
 
 
-	/**
-	 * The supported EC JWK curves by the ECDH crypto provider class.
-	 */
-	public static final Set<Curve> SUPPORTED_ELLIPTIC_CURVES;
+    /**
+     * The supported EC JWK curves by the ECDH crypto provider class.
+     */
+    public static final Set<Curve> SUPPORTED_ELLIPTIC_CURVES;
 
 
-	static {
-		Set<Curve> curves = new LinkedHashSet<>();
-		curves.add(Curve.P_256);
-		curves.add(Curve.P_384);
-		curves.add(Curve.P_521);
-		SUPPORTED_ELLIPTIC_CURVES = Collections.unmodifiableSet(curves);
-	}
+    static {
+        Set<Curve> curves = new LinkedHashSet<>();
+        curves.add(Curve.P_256);
+        curves.add(Curve.P_384);
+        curves.add(Curve.P_521);
+        SUPPORTED_ELLIPTIC_CURVES = Collections.unmodifiableSet(curves);
+    }
 
 
-	/**
-	 * The public JWK key.
-	 */
-	private final ECPublicKey publicKey;
+    /**
+     * The public JWK key.
+     */
+    private final ECPublicKey publicKey;
 
-	/**
-	 * The private JWK key;
-	 */
-	private final ECPrivateKey privateKey;
+    /**
+     * The private JWK key;
+     */
+    private final ECPrivateKey privateKey;
 
-	/**
-	 * The externally supplied AES content encryption key (CEK) to use,
-	 * {@code null} to generate a CEK for each JWE.
-	 */
-	private final SecretKey contentEncryptionKey;
+    /**
+     * The externally supplied AES content encryption key (CEK) to use,
+     * {@code null} to generate a CEK for each JWE.
+     */
+    private final SecretKey contentEncryptionKey;
 
-	/**
-	 * Creates a new Elliptic Curve Diffie-Hellman encrypter.
-	 *
-	 * @param privateKey The private EC key. Must not be {@code null}.
-	 *
-	 * @param publicKey The public EC key. Must not be {@code null}.
-	 *
-	 * @throws JOSEException If the elliptic curve is not supported.
-	 */
-	public ECDH1PUEncrypter(final ECPrivateKey privateKey, final ECPublicKey publicKey)
-		throws JOSEException {
+    /**
+     * Creates a new Elliptic Curve Diffie-Hellman encrypter.
+     *
+     * @param privateKey The private EC key. Must not be {@code null}.
+     *
+     * @param publicKey The public EC key. Must not be {@code null}.
+     *
+     * @throws JOSEException If the elliptic curve is not supported.
+     */
+    public ECDH1PUEncrypter(final ECPrivateKey privateKey, final ECPublicKey publicKey)
+        throws JOSEException {
 
-		this(privateKey, publicKey, null);
-	}
-
-
-	/**
-	 * Creates a new Elliptic Curve Diffie-Hellman encrypter with an
-	 * optionally specified content encryption key (CEK).
-	 *
-	 * @param privateKey            The private EC key. Must not be
-	 *               			   {@code null}.
-	 *
-	 * @param publicKey            The public EC key. Must not be
-	 *                             {@code null}.
-	 * @param contentEncryptionKey The content encryption key (CEK) to use.
-	 *                             If specified its algorithm must be "AES"
-	 *                             and its length must match the expected
-	 *                             for the JWE encryption method ("enc").
-	 *                             If {@code null} a CEK will be generated
-	 *                             for each JWE.
-	 * @throws JOSEException       If the elliptic curve is not supported.
-	 */
-	public ECDH1PUEncrypter(final ECPrivateKey privateKey,
-							final ECPublicKey publicKey,
-							final SecretKey contentEncryptionKey)
-			throws JOSEException {
-
-		super(Curve.forECParameterSpec(publicKey.getParams()));
-
-		this.privateKey = privateKey;
-		this.publicKey = publicKey;
-
-		if (contentEncryptionKey != null && (contentEncryptionKey.getAlgorithm() == null || !contentEncryptionKey.getAlgorithm().equals("AES")))
-			throw new IllegalArgumentException("The algorithm of the content encryption key (CEK) must be AES");
-
-		this.contentEncryptionKey = contentEncryptionKey;
-	}
+        this(privateKey, publicKey, null);
+    }
 
 
-	/**
-	 * Returns the public EC key.
-	 *
-	 * @return The public EC key.
-	 */
-	public ECPublicKey getPublicKey() {
+    /**
+     * Creates a new Elliptic Curve Diffie-Hellman encrypter with an
+     * optionally specified content encryption key (CEK).
+     *
+     * @param privateKey            The private EC key. Must not be
+     *               			   {@code null}.
+     *
+     * @param publicKey            The public EC key. Must not be
+     *                             {@code null}.
+     * @param contentEncryptionKey The content encryption key (CEK) to use.
+     *                             If specified its algorithm must be "AES"
+     *                             and its length must match the expected
+     *                             for the JWE encryption method ("enc").
+     *                             If {@code null} a CEK will be generated
+     *                             for each JWE.
+     * @throws JOSEException       If the elliptic curve is not supported.
+     */
+    public ECDH1PUEncrypter(final ECPrivateKey privateKey,
+                            final ECPublicKey publicKey,
+                            final SecretKey contentEncryptionKey)
+            throws JOSEException {
 
-		return publicKey;
-	}
+        super(Curve.forECParameterSpec(publicKey.getParams()));
 
+        this.privateKey = privateKey;
+        this.publicKey = publicKey;
 
-	/**
-	 * Returns the private EC key.
-	 *
-	 * @return The private EC key.
-	 */
-	public ECPrivateKey getPrivateKey() {
+        if (contentEncryptionKey != null && (contentEncryptionKey.getAlgorithm() == null || !contentEncryptionKey.getAlgorithm().equals("AES")))
+            throw new IllegalArgumentException("The algorithm of the content encryption key (CEK) must be AES");
 
-		return privateKey;
-	}
-
-
-	@Override
-	public Set<Curve> supportedEllipticCurves() {
-
-		return SUPPORTED_ELLIPTIC_CURVES;
-	}
-
-
-	@Override
-	public JWECryptoParts encrypt(final JWEHeader header, final byte[] clearText)
-		throws JOSEException {
-
-		ECDH1PU.validateSameCurve(privateKey, publicKey);
-
-		// Generate ephemeral EC key pair on the same curve as the consumer's public key
-		KeyPair ephemeralKeyPair = generateEphemeralKeyPair(publicKey.getParams());
-		ECPublicKey ephemeralPublicKey = (ECPublicKey)ephemeralKeyPair.getPublic();
-		ECPrivateKey ephemeralPrivateKey = (ECPrivateKey)ephemeralKeyPair.getPrivate();
-
-		// Add the ephemeral public EC key to the header
-		JWEHeader updatedHeader = new JWEHeader.Builder(header).
-			ephemeralPublicKey(new ECKey.Builder(getCurve(), ephemeralPublicKey).build()).
-			build();
-
-		SecretKey Ze = ECDH.deriveSharedSecret(
-			publicKey,
-			ephemeralPrivateKey,
-			getJCAContext().getKeyEncryptionProvider());
-
-		SecretKey Zs = ECDH.deriveSharedSecret(
-				publicKey,
-				privateKey,
-				getJCAContext().getKeyEncryptionProvider());
-
-		SecretKey Z = ECDH1PU.deriveZ(Ze, Zs);
-
-		return encryptWithZ(updatedHeader, Z, clearText, contentEncryptionKey);
-	}
+        this.contentEncryptionKey = contentEncryptionKey;
+    }
 
 
-	/**
-	 * Generates a new ephemeral EC key pair with the specified curve.
-	 *
-	 * @param ecParameterSpec The EC key spec. Must not be {@code null}.
-	 *
-	 * @return The EC key pair.
-	 *
-	 * @throws JOSEException If the EC key pair couldn't be generated.
-	 */
-	private KeyPair generateEphemeralKeyPair(final ECParameterSpec ecParameterSpec)
-		throws JOSEException {
+    /**
+     * Returns the public EC key.
+     *
+     * @return The public EC key.
+     */
+    public ECPublicKey getPublicKey() {
 
-		Provider keProvider = getJCAContext().getKeyEncryptionProvider();
+        return publicKey;
+    }
 
-		try {
-			KeyPairGenerator generator;
 
-			if (keProvider != null) {
-				generator = KeyPairGenerator.getInstance("EC", keProvider);
-			} else {
-				generator = KeyPairGenerator.getInstance("EC");
-			}
+    /**
+     * Returns the private EC key.
+     *
+     * @return The private EC key.
+     */
+    public ECPrivateKey getPrivateKey() {
 
-			generator.initialize(ecParameterSpec);
-			return generator.generateKeyPair();
-		} catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException e) {
-			throw new JOSEException("Couldn't generate ephemeral EC key pair: " + e.getMessage(), e);
-		}
-	}
+        return privateKey;
+    }
+
+
+    @Override
+    public Set<Curve> supportedEllipticCurves() {
+
+        return SUPPORTED_ELLIPTIC_CURVES;
+    }
+
+
+    @Override
+    public JWECryptoParts encrypt(final JWEHeader header, final byte[] clearText)
+        throws JOSEException {
+
+        ECDH1PU.validateSameCurve(privateKey, publicKey);
+
+        // Generate ephemeral EC key pair on the same curve as the consumer's public key
+        KeyPair ephemeralKeyPair = generateEphemeralKeyPair(publicKey.getParams());
+        ECPublicKey ephemeralPublicKey = (ECPublicKey)ephemeralKeyPair.getPublic();
+        ECPrivateKey ephemeralPrivateKey = (ECPrivateKey)ephemeralKeyPair.getPrivate();
+
+        // Add the ephemeral public EC key to the header
+        JWEHeader updatedHeader = new JWEHeader.Builder(header).
+            ephemeralPublicKey(new ECKey.Builder(getCurve(), ephemeralPublicKey).build()).
+            build();
+
+        SecretKey Ze = ECDH.deriveSharedSecret(
+            publicKey,
+            ephemeralPrivateKey,
+            getJCAContext().getKeyEncryptionProvider());
+
+        SecretKey Zs = ECDH.deriveSharedSecret(
+                publicKey,
+                privateKey,
+                getJCAContext().getKeyEncryptionProvider());
+
+        SecretKey Z = ECDH1PU.deriveZ(Ze, Zs);
+
+        return encryptWithZ(updatedHeader, Z, clearText, contentEncryptionKey);
+    }
+
+
+    /**
+     * Generates a new ephemeral EC key pair with the specified curve.
+     *
+     * @param ecParameterSpec The EC key spec. Must not be {@code null}.
+     *
+     * @return The EC key pair.
+     *
+     * @throws JOSEException If the EC key pair couldn't be generated.
+     */
+    private KeyPair generateEphemeralKeyPair(final ECParameterSpec ecParameterSpec)
+        throws JOSEException {
+
+        Provider keProvider = getJCAContext().getKeyEncryptionProvider();
+
+        try {
+            KeyPairGenerator generator;
+
+            if (keProvider != null) {
+                generator = KeyPairGenerator.getInstance("EC", keProvider);
+            } else {
+                generator = KeyPairGenerator.getInstance("EC");
+            }
+
+            generator.initialize(ecParameterSpec);
+            return generator.generateKeyPair();
+        } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException e) {
+            throw new JOSEException("Couldn't generate ephemeral EC key pair: " + e.getMessage(), e);
+        }
+    }
 }

--- a/src/main/java/com/nimbusds/jose/crypto/ECDH1PUEncrypter.java
+++ b/src/main/java/com/nimbusds/jose/crypto/ECDH1PUEncrypter.java
@@ -1,7 +1,7 @@
 /*
  * nimbus-jose-jwt
  *
- * Copyright 2012-2021, Connect2id Ltd.
+ * Copyright 2012-2021, Connect2id Ltd and contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy of the
@@ -82,7 +82,7 @@ import java.util.Set;
  *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512_DEPRECATED}
  * </ul>
  *
- * <p>Supports the following content encryption algorithms for Direct Key wrapping mode:
+ * <p>Supports the following content encryption algorithms for Key wrapping mode:
  *
  * <ul>
  *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256}

--- a/src/main/java/com/nimbusds/jose/crypto/ECDH1PUX25519Decrypter.java
+++ b/src/main/java/com/nimbusds/jose/crypto/ECDH1PUX25519Decrypter.java
@@ -92,140 +92,140 @@ import java.util.Set;
 public class ECDH1PUX25519Decrypter extends ECDH1PUCryptoProvider implements JWEDecrypter, CriticalHeaderParamsAware {
 
 
-	/**
-	 * The private key.
-	 */
-	private final OctetKeyPair privateKey;
+    /**
+     * The private key.
+     */
+    private final OctetKeyPair privateKey;
 
-	/**
-	 * The public key.
-	 */
-	private final OctetKeyPair publicKey;
+    /**
+     * The public key.
+     */
+    private final OctetKeyPair publicKey;
 
-	/**
-	 * The critical header policy.
-	 */
-	private final CriticalHeaderParamsDeferral critPolicy = new CriticalHeaderParamsDeferral();
-
-
-	/**
-	 * Creates a new Curve25519 Elliptic Curve Diffie-Hellman decrypter.
-	 *
-	 * @param privateKey The private key. Must not be {@code null}.
-	 * @param publicKey The private key. Must not be {@code null}.
-	 *
-	 * @throws JOSEException If the key subtype is not supported.
-	 */
-	public ECDH1PUX25519Decrypter(final OctetKeyPair privateKey, final OctetKeyPair publicKey)
-			throws JOSEException {
-
-		this(privateKey, publicKey, null);
-	}
+    /**
+     * The critical header policy.
+     */
+    private final CriticalHeaderParamsDeferral critPolicy = new CriticalHeaderParamsDeferral();
 
 
-	/**
-	 * Creates a new Curve25519 Elliptic Curve Diffie-Hellman decrypter.
-	 *
-	 * @param privateKey     The private key. Must not be {@code null}.
-	 * @param publicKey The private key. Must not be {@code null}.
-	 * @param defCritHeaders The names of the critical header parameters
-	 *                       that are deferred to the application for
-	 *                       processing, empty set or {@code null} if none.
-	 *
-	 * @throws JOSEException If the key subtype is not supported.
-	 */
-	public ECDH1PUX25519Decrypter(final OctetKeyPair privateKey,
-								  final OctetKeyPair publicKey,
-								  final Set<String> defCritHeaders)
-			throws JOSEException {
+    /**
+     * Creates a new Curve25519 Elliptic Curve Diffie-Hellman decrypter.
+     *
+     * @param privateKey The private key. Must not be {@code null}.
+     * @param publicKey The private key. Must not be {@code null}.
+     *
+     * @throws JOSEException If the key subtype is not supported.
+     */
+    public ECDH1PUX25519Decrypter(final OctetKeyPair privateKey, final OctetKeyPair publicKey)
+            throws JOSEException {
 
-		super(privateKey.getCurve());
-
-		this.privateKey = privateKey;
-		this.publicKey = publicKey;
-
-		critPolicy.setDeferredCriticalHeaderParams(defCritHeaders);
-	}
+        this(privateKey, publicKey, null);
+    }
 
 
-	@Override
-	public Set<Curve> supportedEllipticCurves() {
+    /**
+     * Creates a new Curve25519 Elliptic Curve Diffie-Hellman decrypter.
+     *
+     * @param privateKey     The private key. Must not be {@code null}.
+     * @param publicKey The private key. Must not be {@code null}.
+     * @param defCritHeaders The names of the critical header parameters
+     *                       that are deferred to the application for
+     *                       processing, empty set or {@code null} if none.
+     *
+     * @throws JOSEException If the key subtype is not supported.
+     */
+    public ECDH1PUX25519Decrypter(final OctetKeyPair privateKey,
+                                  final OctetKeyPair publicKey,
+                                  final Set<String> defCritHeaders)
+            throws JOSEException {
 
-		return Collections.singleton(Curve.X25519);
-	}
+        super(privateKey.getCurve());
 
+        this.privateKey = privateKey;
+        this.publicKey = publicKey;
 
-	/**
-	 * Returns the private key.
-	 *
-	 * @return The private key.
-	 */
-	public OctetKeyPair getPrivateKey() {
-
-		return privateKey;
-	}
-
-	/**
-	 * Returns the public key.
-	 *
-	 * @return The public key.
-	 */
-	public OctetKeyPair getPublicKey() {
-
-		return publicKey;
-	}
-
-	@Override
-	public Set<String> getProcessedCriticalHeaderParams() {
-
-		return critPolicy.getProcessedCriticalHeaderParams();
-	}
+        critPolicy.setDeferredCriticalHeaderParams(defCritHeaders);
+    }
 
 
-	@Override
-	public Set<String> getDeferredCriticalHeaderParams() {
+    @Override
+    public Set<Curve> supportedEllipticCurves() {
 
-		return critPolicy.getProcessedCriticalHeaderParams();
-	}
+        return Collections.singleton(Curve.X25519);
+    }
 
 
-	@Override
-	public byte[] decrypt(final JWEHeader header,
-						  final Base64URL encryptedKey,
-						  final Base64URL iv,
-						  final Base64URL cipherText,
-						  final Base64URL authTag)
-			throws JOSEException {
+    /**
+     * Returns the private key.
+     *
+     * @return The private key.
+     */
+    public OctetKeyPair getPrivateKey() {
 
-		ECDH1PU.validateSameCurve(privateKey, publicKey);
+        return privateKey;
+    }
 
-		// Check for unrecognizable "crit" properties
-		critPolicy.ensureHeaderPasses(header);
+    /**
+     * Returns the public key.
+     *
+     * @return The public key.
+     */
+    public OctetKeyPair getPublicKey() {
 
-		// Get ephemeral key from header
-		OctetKeyPair ephemeralPublicKey = (OctetKeyPair) header.getEphemeralPublicKey();
+        return publicKey;
+    }
 
-		if (ephemeralPublicKey == null) {
-			throw new JOSEException("Missing ephemeral public key \"epk\" JWE header parameter");
-		}
+    @Override
+    public Set<String> getProcessedCriticalHeaderParams() {
 
-		ECDH1PU.validateSameCurve(privateKey, ephemeralPublicKey);
+        return critPolicy.getProcessedCriticalHeaderParams();
+    }
 
-		SecretKey Ze = ECDH.deriveSharedSecret(
-				ephemeralPublicKey,
-				privateKey);
 
-		SecretKey Zs = ECDH.deriveSharedSecret(
-				publicKey,
-				privateKey);
+    @Override
+    public Set<String> getDeferredCriticalHeaderParams() {
 
-		// Derive 'Z'
-		// Note: X25519 does not require public key validation
-		// See https://cr.yp.to/ecdh.html#validate
-		SecretKey Z = ECDH1PU.deriveZ(Ze, Zs);
+        return critPolicy.getProcessedCriticalHeaderParams();
+    }
 
-		return decryptWithZ(header, Z, encryptedKey, iv, cipherText, authTag);
-	}
+
+    @Override
+    public byte[] decrypt(final JWEHeader header,
+                          final Base64URL encryptedKey,
+                          final Base64URL iv,
+                          final Base64URL cipherText,
+                          final Base64URL authTag)
+            throws JOSEException {
+
+        ECDH1PU.validateSameCurve(privateKey, publicKey);
+
+        // Check for unrecognizable "crit" properties
+        critPolicy.ensureHeaderPasses(header);
+
+        // Get ephemeral key from header
+        OctetKeyPair ephemeralPublicKey = (OctetKeyPair) header.getEphemeralPublicKey();
+
+        if (ephemeralPublicKey == null) {
+            throw new JOSEException("Missing ephemeral public key \"epk\" JWE header parameter");
+        }
+
+        ECDH1PU.validateSameCurve(privateKey, ephemeralPublicKey);
+
+        SecretKey Ze = ECDH.deriveSharedSecret(
+                ephemeralPublicKey,
+                privateKey);
+
+        SecretKey Zs = ECDH.deriveSharedSecret(
+                publicKey,
+                privateKey);
+
+        // Derive 'Z'
+        // Note: X25519 does not require public key validation
+        // See https://cr.yp.to/ecdh.html#validate
+        SecretKey Z = ECDH1PU.deriveZ(Ze, Zs);
+
+        return decryptWithZ(header, Z, encryptedKey, iv, cipherText, authTag);
+    }
 
 
 }

--- a/src/main/java/com/nimbusds/jose/crypto/ECDH1PUX25519Decrypter.java
+++ b/src/main/java/com/nimbusds/jose/crypto/ECDH1PUX25519Decrypter.java
@@ -1,7 +1,7 @@
 /*
  * nimbus-jose-jwt
  *
- * Copyright 2012-2021, Connect2id Ltd.
+ * Copyright 2012-2021, Connect2id Ltd and contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy of the
@@ -61,9 +61,7 @@ import java.util.Set;
  * <p>Supports the following elliptic curves:
  *
  * <ul>
- *     <li>{@link Curve#P_256}
- *     <li>{@link Curve#P_384}
- *     <li>{@link Curve#P_521}
+ *     <li>{@link Curve#X25519}
  * </ul>
  *
  * <p>Supports the following content encryption algorithms for Direct key agreement mode:
@@ -79,7 +77,7 @@ import java.util.Set;
  *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512_DEPRECATED}
  * </ul>
  *
- * <p>Supports the following content encryption algorithms for Direct Key wrapping mode:
+ * <p>Supports the following content encryption algorithms for Key wrapping mode:
  *
  * <ul>
  *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256}

--- a/src/main/java/com/nimbusds/jose/crypto/ECDH1PUX25519Decrypter.java
+++ b/src/main/java/com/nimbusds/jose/crypto/ECDH1PUX25519Decrypter.java
@@ -1,0 +1,252 @@
+/*
+ * nimbus-jose-jwt
+ *
+ * Copyright 2012-2016, Connect2id Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.nimbusds.jose.crypto;
+
+
+import com.nimbusds.jose.CriticalHeaderParamsAware;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEDecrypter;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.crypto.impl.*;
+import com.nimbusds.jose.crypto.utils.ECChecks;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.OctetKeyPair;
+import com.nimbusds.jose.util.Base64URL;
+
+import javax.crypto.SecretKey;
+import java.security.PrivateKey;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+
+/**
+ * Elliptic Curve Diffie-Hellman decrypter of
+ * {@link com.nimbusds.jose.JWEObject JWE objects} for curves using EC JWK
+ * Expects a private {@link OctetKeyPair} key with {@code "crv"} X25519.
+ *
+ * <p>See <a href="https://tools.ietf.org/html/rfc8037">RFC 8037</a>
+ * for more information.
+ *
+ * <p>See also {@link ECDH1PUDecrypter} for ECDH on other curves.
+ *
+ * <p>Public Key Authenticated Encryption for JOSE
+ * <a href="https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04">ECDH-1PU</a>
+ * for more information.
+ *
+ * <p>This class is thread-safe.
+ *
+ * <p>Supports the following key management algorithms:
+ *
+ * <ul>
+ *     <li>{@link com.nimbusds.jose.JWEAlgorithm#ECDH_1PU}
+ *     <li>{@link com.nimbusds.jose.JWEAlgorithm#ECDH_1PU_A128KW}
+ *     <li>{@link com.nimbusds.jose.JWEAlgorithm#ECDH_1PU_A192KW}
+ *     <li>{@link com.nimbusds.jose.JWEAlgorithm#ECDH_1PU_A256KW}
+ * </ul>
+ *
+ * <p>Supports the following elliptic curves:
+ *
+ * <ul>
+ *     <li>{@link Curve#P_256}
+ *     <li>{@link Curve#P_384}
+ *     <li>{@link Curve#P_521}
+ * </ul>
+ *
+ * <p>Supports the following content encryption algorithms for Direct key agreement mode:
+ *
+ * <ul>
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A192CBC_HS384}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128GCM}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A192GCM}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256GCM}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256_DEPRECATED}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512_DEPRECATED}
+ * </ul>
+ *
+ * <p>Supports the following content encryption algorithms for Direct Key wrapping mode:
+ *
+ * <ul>
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A192CBC_HS384}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512}
+ * </ul>
+ *
+ * @author Alexander Martynov
+ * @version 2021-08-03
+ */
+public class ECDH1PUX25519Decrypter extends ECDH1PUCryptoProvider implements JWEDecrypter, CriticalHeaderParamsAware {
+
+
+	/**
+	 * The private key.
+	 */
+	private final OctetKeyPair privateKey;
+
+	/**
+	 * The public key.
+	 */
+	private final OctetKeyPair publicKey;
+
+	/**
+	 * The critical header policy.
+	 */
+	private final CriticalHeaderParamsDeferral critPolicy = new CriticalHeaderParamsDeferral();
+
+
+	/**
+	 * Creates a new Curve25519 Elliptic Curve Diffie-Hellman decrypter.
+	 *
+	 * @param privateKey The private key. Must not be {@code null}.
+	 * @param publicKey The private key. Must not be {@code null}.
+	 *
+	 * @throws JOSEException If the key subtype is not supported.
+	 */
+	public ECDH1PUX25519Decrypter(final OctetKeyPair privateKey, final OctetKeyPair publicKey)
+			throws JOSEException {
+
+		this(privateKey, publicKey, null);
+	}
+
+
+	/**
+	 * Creates a new Curve25519 Elliptic Curve Diffie-Hellman decrypter.
+	 *
+	 * @param privateKey     The private key. Must not be {@code null}.
+	 * @param publicKey The private key. Must not be {@code null}.
+	 * @param defCritHeaders The names of the critical header parameters
+	 *                       that are deferred to the application for
+	 *                       processing, empty set or {@code null} if none.
+	 *
+	 * @throws JOSEException If the key subtype is not supported.
+	 */
+	public ECDH1PUX25519Decrypter(final OctetKeyPair privateKey,
+								  final OctetKeyPair publicKey,
+								  final Set<String> defCritHeaders)
+			throws JOSEException {
+
+		super(privateKey.getCurve());
+
+		if (! Curve.X25519.equals(privateKey.getCurve())) {
+			throw new JOSEException("X25519Decrypter only supports OctetKeyPairs with crv=X25519");
+		}
+
+		if (! Curve.X25519.equals(publicKey.getCurve())) {
+			throw new JOSEException("X25519Decrypter only supports OctetKeyPairs with crv=X25519");
+		}
+
+		if (! privateKey.isPrivate()) {
+			throw new JOSEException("The OctetKeyPair doesn't contain a private part");
+		}
+
+		this.privateKey = privateKey;
+		this.publicKey = publicKey;
+
+		critPolicy.setDeferredCriticalHeaderParams(defCritHeaders);
+	}
+
+
+	@Override
+	public Set<Curve> supportedEllipticCurves() {
+
+		return Collections.singleton(Curve.X25519);
+	}
+
+
+	/**
+	 * Returns the private key.
+	 *
+	 * @return The private key.
+	 */
+	public OctetKeyPair getPrivateKey() {
+
+		return privateKey;
+	}
+
+	/**
+	 * Returns the public key.
+	 *
+	 * @return The public key.
+	 */
+	public OctetKeyPair getPublicKey() {
+
+		return publicKey;
+	}
+
+	@Override
+	public Set<String> getProcessedCriticalHeaderParams() {
+
+		return critPolicy.getProcessedCriticalHeaderParams();
+	}
+
+
+	@Override
+	public Set<String> getDeferredCriticalHeaderParams() {
+
+		return critPolicy.getProcessedCriticalHeaderParams();
+	}
+
+
+	@Override
+	public byte[] decrypt(final JWEHeader header,
+						  final Base64URL encryptedKey,
+						  final Base64URL iv,
+						  final Base64URL cipherText,
+						  final Base64URL authTag)
+			throws JOSEException {
+
+		// Check for unrecognizable "crit" properties
+		critPolicy.ensureHeaderPasses(header);
+
+		// Get ephemeral key from header
+		OctetKeyPair ephemeralPublicKey = (OctetKeyPair) header.getEphemeralPublicKey();
+
+		if (ephemeralPublicKey == null) {
+			throw new JOSEException("Missing ephemeral public key \"epk\" JWE header parameter");
+		}
+
+		if (! privateKey.getCurve().equals(ephemeralPublicKey.getCurve())) {
+			throw new JOSEException("Curve of ephemeral public key does not match curve of private key");
+		}
+
+		// Derive 'Z'
+		// Derive 'Ze'
+		SecretKey Ze = ECDH.deriveSharedSecret(
+				ephemeralPublicKey,
+				privateKey);
+
+		// Derive 'Zs'
+		SecretKey Zs = ECDH.deriveSharedSecret(
+				publicKey,
+				privateKey);
+
+		// Derive 'Z'
+		// Note: X25519 does not require public key validation
+		// See https://cr.yp.to/ecdh.html#validate
+		SecretKey Z = ECDH1PU.deriveZ(Ze, Zs);
+
+		return decryptWithZ(header, Z, encryptedKey, iv, cipherText, authTag);
+	}
+
+
+}

--- a/src/main/java/com/nimbusds/jose/crypto/ECDH1PUX25519Encrypter.java
+++ b/src/main/java/com/nimbusds/jose/crypto/ECDH1PUX25519Encrypter.java
@@ -1,0 +1,216 @@
+/*
+ * nimbus-jose-jwt
+ *
+ * Copyright 2012-2019, Connect2id Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.nimbusds.jose.crypto;
+
+
+import com.google.crypto.tink.subtle.X25519;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWECryptoParts;
+import com.nimbusds.jose.JWEEncrypter;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.crypto.impl.ECDH;
+import com.nimbusds.jose.crypto.impl.ECDH1PU;
+import com.nimbusds.jose.crypto.impl.ECDH1PUCryptoProvider;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.OctetKeyPair;
+import com.nimbusds.jose.util.Base64URL;
+import net.jcip.annotations.ThreadSafe;
+
+import javax.crypto.SecretKey;
+import java.security.*;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+
+/**
+ * Elliptic Curve Diffie-Hellman encrypter of
+ * {@link com.nimbusds.jose.JWEObject JWE objects} for curves using EC JWK keys.
+ * Expects a public {@link OctetKeyPair} key with {@code "crv"} X25519.
+ *
+ * <p>See <a href="https://tools.ietf.org/html/rfc8037">RFC 8037</a>
+ * for more information.
+ *
+ * <p>See also {@link ECDH1PUEncrypter} for ECDH on other curves.
+ *
+ * <p>Public Key Authenticated Encryption for JOSE
+ * <a href="https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04">ECDH-1PU</a>
+ * for more information.
+ *
+ * <p>This class is thread-safe.
+ *
+ * <p>Supports the following key management algorithms:
+ *
+ * <ul>
+ *     <li>{@link com.nimbusds.jose.JWEAlgorithm#ECDH_1PU}
+ *     <li>{@link com.nimbusds.jose.JWEAlgorithm#ECDH_1PU_A128KW}
+ *     <li>{@link com.nimbusds.jose.JWEAlgorithm#ECDH_1PU_A192KW}
+ *     <li>{@link com.nimbusds.jose.JWEAlgorithm#ECDH_1PU_A256KW}
+ * </ul>
+ *
+ * <p>Supports the following elliptic curves:
+ *
+ * <ul>
+ *     <li>{@link Curve#P_256}
+ *     <li>{@link Curve#P_384}
+ *     <li>{@link Curve#P_521}
+ * </ul>
+ *
+ * <p>Supports the following content encryption algorithms for Direct key agreement mode:
+ *
+ * <ul>
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A192CBC_HS384}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128GCM}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A192GCM}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256GCM}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256_DEPRECATED}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512_DEPRECATED}
+ * </ul>
+ *
+ * <p>Supports the following content encryption algorithms for Direct Key wrapping mode:
+ *
+ * <ul>
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A192CBC_HS384}
+ *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512}
+ * </ul>
+ *
+ * @author Alexander Martynov
+ * @version 2021-08-03
+ */
+@ThreadSafe
+public class ECDH1PUX25519Encrypter extends ECDH1PUCryptoProvider implements JWEEncrypter {
+
+
+	/**
+	 * The public key.
+	 */
+	private final OctetKeyPair publicKey;
+
+	/**
+	 * The private key.
+	 */
+	private final OctetKeyPair privateKey;
+
+
+	/**
+	 * Creates a new Curve25519 Elliptic Curve Diffie-Hellman encrypter.
+	 *
+	 * @param privateKey The private key. Must not be {@code null}.
+	 * @param publicKey The public key. Must not be {@code null}.
+	 *
+	 * @throws JOSEException If the key subtype is not supported.
+	 */
+	public ECDH1PUX25519Encrypter(final OctetKeyPair privateKey, final OctetKeyPair publicKey)
+			throws JOSEException {
+
+		super(publicKey.getCurve());
+
+		if (! Curve.X25519.equals(privateKey.getCurve())) {
+			throw new JOSEException("X25519Encrypter only supports OctetKeyPairs with crv=X25519");
+		}
+
+		if (! Curve.X25519.equals(publicKey.getCurve())) {
+			throw new JOSEException("X25519Encrypter only supports OctetKeyPairs with crv=X25519");
+		}
+
+		if (publicKey.isPrivate()) {
+			throw new JOSEException("X25519Encrypter requires a public key, use OctetKeyPair.toPublicJWK()");
+		}
+
+		this.publicKey = publicKey;
+		this.privateKey = privateKey;
+	}
+
+
+	@Override
+	public Set<Curve> supportedEllipticCurves() {
+
+		return Collections.singleton(Curve.X25519);
+	}
+
+
+	/**
+	 * Returns the public key.
+	 *
+	 * @return The public key.
+	 */
+	public OctetKeyPair getPublicKey() {
+
+		return publicKey;
+	}
+
+	/**
+	 * Returns the private key.
+	 *
+	 * @return The private key.
+	 */
+	public OctetKeyPair getPrivateKey() {
+
+		return privateKey;
+	}
+
+	@Override
+	public JWECryptoParts encrypt(final JWEHeader header, final byte[] clearText)
+			throws JOSEException {
+
+		// Generate ephemeral X25519 key pair
+		final byte[] ephemeralPrivateKeyBytes = X25519.generatePrivateKey();
+		final byte[] ephemeralPublicKeyBytes;
+		try {
+			ephemeralPublicKeyBytes = X25519.publicFromPrivate(ephemeralPrivateKeyBytes);
+
+		} catch (InvalidKeyException e) {
+			// Should never happen since we just generated this private key
+			throw new JOSEException(e.getMessage(), e);
+		}
+
+		final OctetKeyPair ephemeralPrivateKey =
+				new OctetKeyPair.Builder(getCurve(), Base64URL.encode(ephemeralPublicKeyBytes)).
+						d(Base64URL.encode(ephemeralPrivateKeyBytes)).
+						build();
+		final OctetKeyPair ephemeralPublicKey = ephemeralPrivateKey.toPublicJWK();
+
+		// Add the ephemeral public EC key to the header
+		JWEHeader updatedHeader = new JWEHeader.Builder(header).
+				ephemeralPublicKey(ephemeralPublicKey).
+				build();
+
+		// Derive 'Z'
+		// Derive 'Ze'
+		SecretKey Ze = ECDH.deriveSharedSecret(
+				publicKey,
+				ephemeralPrivateKey);
+
+		// Derive 'Zs'
+		SecretKey Zs = ECDH.deriveSharedSecret(
+				publicKey,
+				privateKey);
+
+		// Derive 'Z'
+		SecretKey Z = ECDH1PU.deriveZ(Ze, Zs);
+
+		return encryptWithZ(updatedHeader, Z, clearText);
+	}
+}

--- a/src/main/java/com/nimbusds/jose/crypto/ECDH1PUX25519Encrypter.java
+++ b/src/main/java/com/nimbusds/jose/crypto/ECDH1PUX25519Encrypter.java
@@ -28,6 +28,7 @@ import com.nimbusds.jose.crypto.impl.ECDH1PU;
 import com.nimbusds.jose.crypto.impl.ECDH1PUCryptoProvider;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.OctetKeyPair;
+import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator;
 import com.nimbusds.jose.util.Base64URL;
 import net.jcip.annotations.ThreadSafe;
 
@@ -190,21 +191,7 @@ public class ECDH1PUX25519Encrypter extends ECDH1PUCryptoProvider implements JWE
 
         ECDH1PU.validateSameCurve(privateKey, publicKey);
 
-        // Generate ephemeral X25519 key pair
-        final byte[] ephemeralPrivateKeyBytes = X25519.generatePrivateKey();
-        final byte[] ephemeralPublicKeyBytes;
-        try {
-            ephemeralPublicKeyBytes = X25519.publicFromPrivate(ephemeralPrivateKeyBytes);
-
-        } catch (InvalidKeyException e) {
-            // Should never happen since we just generated this private key
-            throw new JOSEException(e.getMessage(), e);
-        }
-
-        final OctetKeyPair ephemeralPrivateKey =
-                new OctetKeyPair.Builder(getCurve(), Base64URL.encode(ephemeralPublicKeyBytes)).
-                        d(Base64URL.encode(ephemeralPrivateKeyBytes)).
-                        build();
+        final OctetKeyPair ephemeralPrivateKey = new OctetKeyPairGenerator(getCurve()).generate();
         final OctetKeyPair ephemeralPublicKey = ephemeralPrivateKey.toPublicJWK();
 
         // Add the ephemeral public EC key to the header

--- a/src/main/java/com/nimbusds/jose/crypto/ECDH1PUX25519Encrypter.java
+++ b/src/main/java/com/nimbusds/jose/crypto/ECDH1PUX25519Encrypter.java
@@ -1,7 +1,7 @@
 /*
  * nimbus-jose-jwt
  *
- * Copyright 2012-2021, Connect2id Ltd.
+ * Copyright 2012-2021, Connect2id Ltd and contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy of the
@@ -65,9 +65,7 @@ import java.util.Set;
  * <p>Supports the following elliptic curves:
  *
  * <ul>
- *     <li>{@link Curve#P_256}
- *     <li>{@link Curve#P_384}
- *     <li>{@link Curve#P_521}
+ *     <li>{@link Curve#X25519}
  * </ul>
  *
  * <p>Supports the following content encryption algorithms for Direct key agreement mode:
@@ -83,7 +81,7 @@ import java.util.Set;
  *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512_DEPRECATED}
  * </ul>
  *
- * <p>Supports the following content encryption algorithms for Direct Key wrapping mode:
+ * <p>Supports the following content encryption algorithms for Key wrapping mode:
  *
  * <ul>
  *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256}

--- a/src/main/java/com/nimbusds/jose/crypto/ECDH1PUX25519Encrypter.java
+++ b/src/main/java/com/nimbusds/jose/crypto/ECDH1PUX25519Encrypter.java
@@ -96,132 +96,132 @@ import java.util.Set;
 public class ECDH1PUX25519Encrypter extends ECDH1PUCryptoProvider implements JWEEncrypter {
 
 
-	/**
-	 * The public key.
-	 */
-	private final OctetKeyPair publicKey;
+    /**
+     * The public key.
+     */
+    private final OctetKeyPair publicKey;
 
-	/**
-	 * The private key.
-	 */
-	private final OctetKeyPair privateKey;
+    /**
+     * The private key.
+     */
+    private final OctetKeyPair privateKey;
 
-	/**
-	 * The externally supplied AES content encryption key (CEK) to use,
-	 * {@code null} to generate a CEK for each JWE.
-	 */
-	private final SecretKey contentEncryptionKey;
+    /**
+     * The externally supplied AES content encryption key (CEK) to use,
+     * {@code null} to generate a CEK for each JWE.
+     */
+    private final SecretKey contentEncryptionKey;
 
-	/**
-	 * Creates a new Curve25519 Elliptic Curve Diffie-Hellman encrypter.
-	 *
-	 * @param privateKey The private key. Must not be {@code null}.
-	 * @param publicKey The public key. Must not be {@code null}.
-	 *
-	 * @throws JOSEException If the key subtype is not supported.
-	 */
-	public ECDH1PUX25519Encrypter(final OctetKeyPair privateKey, final OctetKeyPair publicKey)
-			throws JOSEException {
+    /**
+     * Creates a new Curve25519 Elliptic Curve Diffie-Hellman encrypter.
+     *
+     * @param privateKey The private key. Must not be {@code null}.
+     * @param publicKey The public key. Must not be {@code null}.
+     *
+     * @throws JOSEException If the key subtype is not supported.
+     */
+    public ECDH1PUX25519Encrypter(final OctetKeyPair privateKey, final OctetKeyPair publicKey)
+            throws JOSEException {
 
-		this(privateKey, publicKey, null);
-	}
+        this(privateKey, publicKey, null);
+    }
 
-	/**
-	 * Creates a new Curve25519 Elliptic Curve Diffie-Hellman encrypter.
-	 *
-	 * @param privateKey The private key. Must not be {@code null}.
-	 * @param publicKey The public key. Must not be {@code null}.
-	 * @param contentEncryptionKey The content encryption key (CEK) to use.
-	 *                             If specified its algorithm must be "AES"
-	 *                             and its length must match the expected
-	 *                             for the JWE encryption method ("enc").
-	 *                             If {@code null} a CEK will be generated
-	 *                             for each JWE.
-	 *
-	 * @throws JOSEException If the key subtype is not supported.
-	 */
-	public ECDH1PUX25519Encrypter(final OctetKeyPair privateKey,
-								  final OctetKeyPair publicKey,
-								  final SecretKey contentEncryptionKey
-								  )
-			throws JOSEException {
+    /**
+     * Creates a new Curve25519 Elliptic Curve Diffie-Hellman encrypter.
+     *
+     * @param privateKey The private key. Must not be {@code null}.
+     * @param publicKey The public key. Must not be {@code null}.
+     * @param contentEncryptionKey The content encryption key (CEK) to use.
+     *                             If specified its algorithm must be "AES"
+     *                             and its length must match the expected
+     *                             for the JWE encryption method ("enc").
+     *                             If {@code null} a CEK will be generated
+     *                             for each JWE.
+     *
+     * @throws JOSEException If the key subtype is not supported.
+     */
+    public ECDH1PUX25519Encrypter(final OctetKeyPair privateKey,
+                                  final OctetKeyPair publicKey,
+                                  final SecretKey contentEncryptionKey
+                                  )
+            throws JOSEException {
 
-		super(publicKey.getCurve());
+        super(publicKey.getCurve());
 
-		this.publicKey = publicKey;
-		this.privateKey = privateKey;
+        this.publicKey = publicKey;
+        this.privateKey = privateKey;
 
-		if (contentEncryptionKey != null && (contentEncryptionKey.getAlgorithm() == null || !contentEncryptionKey.getAlgorithm().equals("AES")))
-			throw new IllegalArgumentException("The algorithm of the content encryption key (CEK) must be AES");
+        if (contentEncryptionKey != null && (contentEncryptionKey.getAlgorithm() == null || !contentEncryptionKey.getAlgorithm().equals("AES")))
+            throw new IllegalArgumentException("The algorithm of the content encryption key (CEK) must be AES");
 
-		this.contentEncryptionKey = contentEncryptionKey;
-	}
+        this.contentEncryptionKey = contentEncryptionKey;
+    }
 
-	@Override
-	public Set<Curve> supportedEllipticCurves() {
+    @Override
+    public Set<Curve> supportedEllipticCurves() {
 
-		return Collections.singleton(Curve.X25519);
-	}
+        return Collections.singleton(Curve.X25519);
+    }
 
 
-	/**
-	 * Returns the public key.
-	 *
-	 * @return The public key.
-	 */
-	public OctetKeyPair getPublicKey() {
+    /**
+     * Returns the public key.
+     *
+     * @return The public key.
+     */
+    public OctetKeyPair getPublicKey() {
 
-		return publicKey;
-	}
+        return publicKey;
+    }
 
-	/**
-	 * Returns the private key.
-	 *
-	 * @return The private key.
-	 */
-	public OctetKeyPair getPrivateKey() {
+    /**
+     * Returns the private key.
+     *
+     * @return The private key.
+     */
+    public OctetKeyPair getPrivateKey() {
 
-		return privateKey;
-	}
+        return privateKey;
+    }
 
-	@Override
-	public JWECryptoParts encrypt(final JWEHeader header, final byte[] clearText)
-			throws JOSEException {
+    @Override
+    public JWECryptoParts encrypt(final JWEHeader header, final byte[] clearText)
+            throws JOSEException {
 
-		ECDH1PU.validateSameCurve(privateKey, publicKey);
+        ECDH1PU.validateSameCurve(privateKey, publicKey);
 
-		// Generate ephemeral X25519 key pair
-		final byte[] ephemeralPrivateKeyBytes = X25519.generatePrivateKey();
-		final byte[] ephemeralPublicKeyBytes;
-		try {
-			ephemeralPublicKeyBytes = X25519.publicFromPrivate(ephemeralPrivateKeyBytes);
+        // Generate ephemeral X25519 key pair
+        final byte[] ephemeralPrivateKeyBytes = X25519.generatePrivateKey();
+        final byte[] ephemeralPublicKeyBytes;
+        try {
+            ephemeralPublicKeyBytes = X25519.publicFromPrivate(ephemeralPrivateKeyBytes);
 
-		} catch (InvalidKeyException e) {
-			// Should never happen since we just generated this private key
-			throw new JOSEException(e.getMessage(), e);
-		}
+        } catch (InvalidKeyException e) {
+            // Should never happen since we just generated this private key
+            throw new JOSEException(e.getMessage(), e);
+        }
 
-		final OctetKeyPair ephemeralPrivateKey =
-				new OctetKeyPair.Builder(getCurve(), Base64URL.encode(ephemeralPublicKeyBytes)).
-						d(Base64URL.encode(ephemeralPrivateKeyBytes)).
-						build();
-		final OctetKeyPair ephemeralPublicKey = ephemeralPrivateKey.toPublicJWK();
+        final OctetKeyPair ephemeralPrivateKey =
+                new OctetKeyPair.Builder(getCurve(), Base64URL.encode(ephemeralPublicKeyBytes)).
+                        d(Base64URL.encode(ephemeralPrivateKeyBytes)).
+                        build();
+        final OctetKeyPair ephemeralPublicKey = ephemeralPrivateKey.toPublicJWK();
 
-		// Add the ephemeral public EC key to the header
-		JWEHeader updatedHeader = new JWEHeader.Builder(header).
-				ephemeralPublicKey(ephemeralPublicKey).
-				build();
+        // Add the ephemeral public EC key to the header
+        JWEHeader updatedHeader = new JWEHeader.Builder(header).
+                ephemeralPublicKey(ephemeralPublicKey).
+                build();
 
-		SecretKey Ze = ECDH.deriveSharedSecret(
-				publicKey,
-				ephemeralPrivateKey);
+        SecretKey Ze = ECDH.deriveSharedSecret(
+                publicKey,
+                ephemeralPrivateKey);
 
-		SecretKey Zs = ECDH.deriveSharedSecret(
-				publicKey,
-				privateKey);
+        SecretKey Zs = ECDH.deriveSharedSecret(
+                publicKey,
+                privateKey);
 
-		SecretKey Z = ECDH1PU.deriveZ(Ze, Zs);
+        SecretKey Z = ECDH1PU.deriveZ(Ze, Zs);
 
-		return encryptWithZ(updatedHeader, Z, clearText, contentEncryptionKey);
-	}
+        return encryptWithZ(updatedHeader, Z, clearText, contentEncryptionKey);
+    }
 }

--- a/src/main/java/com/nimbusds/jose/crypto/impl/ConcatKDF.java
+++ b/src/main/java/com/nimbusds/jose/crypto/impl/ConcatKDF.java
@@ -176,6 +176,36 @@ public class ConcatKDF implements JCAAware<JCAContext> {
 		return deriveKey(sharedSecret, keyLength, otherInfo);
 	}
 
+	/**
+	 * Derives a key from the specified inputs.
+	 *
+	 * @param sharedSecret The shared secret. Must not be {@code null}.
+	 * @param keyLength    The length of the key to derive, in bits.
+	 * @param algID        The algorithm identifier, {@code null} if not
+	 *                     specified.
+	 * @param partyUInfo   The partyUInfo, {@code null} if not specified.
+	 * @param partyVInfo   The partyVInfo {@code null} if not specified.
+	 * @param suppPubInfo  The suppPubInfo, {@code null} if not specified.
+	 * @param suppPrivInfo The suppPrivInfo, {@code null} if not specified.
+	 *
+	 * @return The derived key, with algorithm set to "AES".
+	 *
+	 * @throws JOSEException If the key derivation failed.
+	 */
+	public SecretKey deriveKey(final SecretKey sharedSecret,
+				   final int keyLength,
+			       final byte[] algID,
+			       final byte[] partyUInfo,
+				   final byte[] partyVInfo,
+			       final byte[] suppPubInfo,
+				   final byte[] suppPrivInfo,
+				   final byte[] tag)
+			throws JOSEException {
+
+		final byte[] otherInfo = composeOtherInfo(algID, partyUInfo, partyVInfo, suppPubInfo, suppPrivInfo, tag);
+
+		return deriveKey(sharedSecret, keyLength, otherInfo);
+	}
 
 	/**
 	 * Composes the other info as {@code algID || partyUInfo || partyVInfo
@@ -197,6 +227,30 @@ public class ConcatKDF implements JCAAware<JCAContext> {
 					      final byte[] suppPrivInfo) {
 
 		return ByteUtils.concat(algID, partyUInfo, partyVInfo, suppPubInfo, suppPrivInfo);
+	}
+
+	/**
+	 * Composes the other info as {@code algID || tag || partyUInfo || partyVInfo
+	 * || suppPubInfo || suppPrivInfo}.
+	 *
+	 * @param algID        The algorithm identifier, {@code null} if not
+	 *                     specified.
+	 * @param partyUInfo   The partyUInfo, {@code null} if not specified.
+	 * @param partyVInfo   The partyVInfo {@code null} if not specified.
+	 * @param suppPubInfo  The suppPubInfo, {@code null} if not specified.
+	 * @param suppPrivInfo The suppPrivInfo, {@code null} if not specified.
+	 * @param tag          The cctag, {@code null} if not specified.
+	 *
+	 * @return The resulting other info.
+	 */
+	public static byte[] composeOtherInfo(final byte[] algID,
+						  final byte[] partyUInfo,
+						  final byte[] partyVInfo,
+						  final byte[] suppPubInfo,
+						  final byte[] suppPrivInfo,
+						  final byte[] tag) {
+
+		return ByteUtils.concat(algID, partyUInfo, partyVInfo, suppPubInfo, suppPrivInfo, tag);
 	}
 
 

--- a/src/main/java/com/nimbusds/jose/crypto/impl/ConcatKDF.java
+++ b/src/main/java/com/nimbusds/jose/crypto/impl/ConcatKDF.java
@@ -230,8 +230,8 @@ public class ConcatKDF implements JCAAware<JCAContext> {
 	}
 
 	/**
-	 * Composes the other info as {@code algID || tag || partyUInfo || partyVInfo
-	 * || suppPubInfo || suppPrivInfo}.
+	 * Composes the other info as {@code algID || partyUInfo || partyVInfo
+	 * || suppPubInfo || suppPrivInfo || tag}.
 	 *
 	 * @param algID        The algorithm identifier, {@code null} if not
 	 *                     specified.

--- a/src/main/java/com/nimbusds/jose/crypto/impl/ConcatKDF.java
+++ b/src/main/java/com/nimbusds/jose/crypto/impl/ConcatKDF.java
@@ -193,13 +193,13 @@ public class ConcatKDF implements JCAAware<JCAContext> {
 	 * @throws JOSEException If the key derivation failed.
 	 */
 	public SecretKey deriveKey(final SecretKey sharedSecret,
-				   final int keyLength,
-			       final byte[] algID,
-			       final byte[] partyUInfo,
-				   final byte[] partyVInfo,
-			       final byte[] suppPubInfo,
-				   final byte[] suppPrivInfo,
-				   final byte[] tag)
+                   final int keyLength,
+                   final byte[] algID,
+                   final byte[] partyUInfo,
+                   final byte[] partyVInfo,
+                   final byte[] suppPubInfo,
+                   final byte[] suppPrivInfo,
+                   final byte[] tag)
 			throws JOSEException {
 
 		final byte[] otherInfo = composeOtherInfo(algID, partyUInfo, partyVInfo, suppPubInfo, suppPrivInfo, tag);

--- a/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PU.java
+++ b/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PU.java
@@ -1,0 +1,239 @@
+/*
+ * nimbus-jose-jwt
+ *
+ * Copyright 2012-2016, Connect2id Ltd and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.nimbusds.jose.crypto.impl;
+
+
+import com.nimbusds.jose.*;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jose.util.ByteUtils;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+
+
+/**
+ * Elliptic Curve Diffie-Hellman One-Pass Unified Model (ECDH-1PU)
+ * key agreement functions and utilities.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04">Public Key Authenticated Encryption for JOSE: ECDH-1PU</a>
+ *
+ * @author Alexander Martynov
+ * @version 2021-08-03
+ */
+public class ECDH1PU {
+
+	/**
+	 * Resolves the ECDH algorithm mode.
+	 *
+	 * @param alg The JWE algorithm. Must be supported and not
+	 *            {@code null}.
+	 *
+	 * @return The algorithm mode.
+	 *
+	 * @throws JOSEException If the JWE algorithm is not supported.
+	 */
+	public static ECDH.AlgorithmMode resolveAlgorithmMode(final JWEAlgorithm alg)
+		throws JOSEException {
+
+		if (alg.equals(JWEAlgorithm.ECDH_1PU)) {
+
+			return ECDH.AlgorithmMode.DIRECT;
+
+		} else if (alg.equals(JWEAlgorithm.ECDH_1PU_A128KW) ||
+				alg.equals(JWEAlgorithm.ECDH_1PU_A192KW) ||
+				alg.equals(JWEAlgorithm.ECDH_1PU_A256KW)
+		) {
+
+			return ECDH.AlgorithmMode.KW;
+		} else {
+
+			throw new JOSEException(AlgorithmSupportMessage.unsupportedJWEAlgorithm(
+				alg,
+				ECDHCryptoProvider.SUPPORTED_ALGORITHMS));
+		}
+	}
+
+
+	/**
+	 * Returns the bit length of the shared key (derived via concat KDF)
+	 * for the specified JWE ECDH algorithm.
+	 *
+	 * @param alg The JWE ECDH algorithm. Must be supported and not
+	 *            {@code null}.
+	 * @param enc The encryption method. Must be supported} and not
+	 *            {@code null}.
+	 *
+	 * @return The bit length of the shared key.
+	 *
+	 * @throws JOSEException If the JWE algorithm or encryption method is
+	 *                       not supported.
+	 */
+	public static int sharedKeyLength(final JWEAlgorithm alg, final EncryptionMethod enc)
+		throws JOSEException {
+
+		if (alg.equals(JWEAlgorithm.ECDH_1PU)) {
+
+			int length = enc.cekBitLength();
+
+			if (length == 0) {
+				throw new JOSEException("Unsupported JWE encryption method " + enc);
+			}
+
+			return length;
+
+		} else if (alg.equals(JWEAlgorithm.ECDH_1PU_A128KW)) {
+			return 128;
+		} else if (alg.equals(JWEAlgorithm.ECDH_1PU_A192KW)) {
+			return  192;
+		} else if (alg.equals(JWEAlgorithm.ECDH_1PU_A256KW)) {
+			return  256;
+		} else {
+			throw new JOSEException(AlgorithmSupportMessage.unsupportedJWEAlgorithm(
+				alg, ECDHCryptoProvider.SUPPORTED_ALGORITHMS));
+		}
+	}
+
+	/**
+	 * Derives a shared key (via concat KDF).
+	 *
+	 * @param header    The JWE header. Its algorithm and encryption method
+	 *                  must be supported. Must not be {@code null}.
+	 * @param Z         The derived shared secret ('Z'). Must not be
+	 *                  {@code null}.
+	 * @param concatKDF The concat KDF. Must be initialised and not
+	 *                  {@code null}.
+	 *
+	 * @return The derived shared key.
+	 *
+	 * @throws JOSEException If derivation of the shared key failed.
+	 */
+	public static SecretKey deriveSharedKey(final JWEHeader header,
+											final SecretKey Z,
+											final ConcatKDF concatKDF)
+			throws JOSEException {
+
+		final int sharedKeyLength = sharedKeyLength(header.getAlgorithm(), header.getEncryptionMethod());
+
+		// Set the alg ID for the concat KDF
+		ECDH.AlgorithmMode algMode = resolveAlgorithmMode(header.getAlgorithm());
+
+		final String algID;
+
+		if (algMode == ECDH.AlgorithmMode.DIRECT) {
+			// algID = enc
+			algID = header.getEncryptionMethod().getName();
+		} else if (algMode == ECDH.AlgorithmMode.KW) {
+			// algID = alg
+			algID = header.getAlgorithm().getName();
+		} else {
+			throw new JOSEException("Unsupported JWE ECDH algorithm mode: " + algMode);
+		}
+
+		return concatKDF.deriveKey(
+				Z,
+				sharedKeyLength,
+				ConcatKDF.encodeDataWithLength(algID.getBytes(StandardCharsets.US_ASCII)),
+				ConcatKDF.encodeDataWithLength(header.getAgreementPartyUInfo()),
+				ConcatKDF.encodeDataWithLength(header.getAgreementPartyVInfo()),
+				ConcatKDF.encodeIntData(sharedKeyLength),
+				ConcatKDF.encodeNoData()
+		);
+	}
+
+	/**
+	 * Derives a shared key (via concat KDF).
+	 *
+	 * @param header    The JWE header. Its algorithm and encryption method
+	 *                  must be supported. Must not be {@code null}.
+	 * @param Z         The derived shared secret ('Z'). Must not be
+	 *                  {@code null}.
+	 * @param tag       In Direct Key Agreement mode this is set to an empty octet
+	 *       			string. In Key Agreement with Key Wrapping mode, this is set to a
+	 *       			value of the form Data, where Data is the raw octets of
+	 *       			the JWE Authentication Tag.
+	 * @param concatKDF The concat KDF. Must be initialised and not
+	 *                  {@code null}.
+	 *
+	 * @return The derived shared key.
+	 *
+	 * @throws JOSEException If derivation of the shared key failed.
+	 */
+	public static SecretKey deriveSharedKey(final JWEHeader header,
+						final SecretKey Z,
+						final Base64URL tag,
+						final ConcatKDF concatKDF)
+		throws JOSEException {
+
+		final int sharedKeyLength = sharedKeyLength(header.getAlgorithm(), header.getEncryptionMethod());
+
+		// Set the alg ID for the concat KDF
+		ECDH.AlgorithmMode algMode = resolveAlgorithmMode(header.getAlgorithm());
+
+		final String algID;
+
+		if (algMode == ECDH.AlgorithmMode.DIRECT) {
+			// algID = enc
+			algID = header.getEncryptionMethod().getName();
+		} else if (algMode == ECDH.AlgorithmMode.KW) {
+			// algID = alg
+			algID = header.getAlgorithm().getName();
+		} else {
+			throw new JOSEException("Unsupported JWE ECDH algorithm mode: " + algMode);
+		}
+
+		return concatKDF.deriveKey(
+			Z,
+			sharedKeyLength,
+			ConcatKDF.encodeDataWithLength(algID.getBytes(StandardCharsets.US_ASCII)),
+			ConcatKDF.encodeDataWithLength(header.getAgreementPartyUInfo()),
+			ConcatKDF.encodeDataWithLength(header.getAgreementPartyVInfo()),
+			ConcatKDF.encodeIntData(sharedKeyLength),
+			ConcatKDF.encodeNoData(),
+            ConcatKDF.encodeDataWithLength(tag)
+		);
+	}
+
+	/**
+	 * Derives a shared secret (also called 'Z') where Z is the
+	 * concatenation of Ze and Zs.
+	 *
+	 * @param Ze	The shared secret derived from applying the ECDH primitive
+	 *              to the sender's ephemeral private key and the recipient's
+	 *              static public key (when sending) or the recipient's
+	 *              static private key and the sender's ephemeral public
+	 *       	 	key (when receiving) Must not be {@code null}.
+	 * @param Zs 	The shared secret derived from
+	 *       		applying the ECDH primitive to the sender's static private key and
+	 *       		the recipient's static public key (when sending) or the
+	 *       		recipient's static private key and the sender's static public key
+	 *       		(when receiving). Must not be {@code null}.
+	 * @return		The derived shared key.
+	 */
+	public static SecretKey deriveZ(final SecretKey Ze, final SecretKey Zs) {
+		byte[] encodedKey = ByteUtils.concat(Ze.getEncoded(), Zs.getEncoded());
+		return new SecretKeySpec(encodedKey, 0, encodedKey.length, "AES");
+	}
+
+	/**
+	 * Prevents public instantiation.
+	 */
+	private ECDH1PU() {
+
+	}
+}

--- a/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PU.java
+++ b/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PU.java
@@ -43,254 +43,254 @@ import java.security.interfaces.ECPublicKey;
  */
 public class ECDH1PU {
 
-	/**
-	 * Resolves the ECDH algorithm mode.
-	 *
-	 * @param alg The JWE algorithm. Must be supported and not
-	 *            {@code null}.
-	 *
-	 * @return The algorithm mode.
-	 *
-	 * @throws JOSEException If the JWE algorithm is not supported.
-	 */
-	public static ECDH.AlgorithmMode resolveAlgorithmMode(final JWEAlgorithm alg)
-		throws JOSEException {
+    /**
+     * Resolves the ECDH algorithm mode.
+     *
+     * @param alg The JWE algorithm. Must be supported and not
+     *            {@code null}.
+     *
+     * @return The algorithm mode.
+     *
+     * @throws JOSEException If the JWE algorithm is not supported.
+     */
+    public static ECDH.AlgorithmMode resolveAlgorithmMode(final JWEAlgorithm alg)
+        throws JOSEException {
 
-		if (alg.equals(JWEAlgorithm.ECDH_1PU)) {
+        if (alg.equals(JWEAlgorithm.ECDH_1PU)) {
 
-			return ECDH.AlgorithmMode.DIRECT;
+            return ECDH.AlgorithmMode.DIRECT;
 
-		} else if (alg.equals(JWEAlgorithm.ECDH_1PU_A128KW) ||
-				alg.equals(JWEAlgorithm.ECDH_1PU_A192KW) ||
-				alg.equals(JWEAlgorithm.ECDH_1PU_A256KW)
-		) {
+        } else if (alg.equals(JWEAlgorithm.ECDH_1PU_A128KW) ||
+                alg.equals(JWEAlgorithm.ECDH_1PU_A192KW) ||
+                alg.equals(JWEAlgorithm.ECDH_1PU_A256KW)
+        ) {
 
-			return ECDH.AlgorithmMode.KW;
-		} else {
+            return ECDH.AlgorithmMode.KW;
+        } else {
 
-			throw new JOSEException(AlgorithmSupportMessage.unsupportedJWEAlgorithm(
-				alg,
-				ECDHCryptoProvider.SUPPORTED_ALGORITHMS));
-		}
-	}
+            throw new JOSEException(AlgorithmSupportMessage.unsupportedJWEAlgorithm(
+                alg,
+                ECDHCryptoProvider.SUPPORTED_ALGORITHMS));
+        }
+    }
 
 
-	/**
-	 * Returns the bit length of the shared key (derived via concat KDF)
-	 * for the specified JWE ECDH algorithm.
-	 *
-	 * @param alg The JWE ECDH algorithm. Must be supported and not
-	 *            {@code null}.
-	 * @param enc The encryption method. Must be supported} and not
-	 *            {@code null}.
-	 *
-	 * @return The bit length of the shared key.
-	 *
-	 * @throws JOSEException If the JWE algorithm or encryption method is
-	 *                       not supported.
-	 */
-	public static int sharedKeyLength(final JWEAlgorithm alg, final EncryptionMethod enc)
-		throws JOSEException {
+    /**
+     * Returns the bit length of the shared key (derived via concat KDF)
+     * for the specified JWE ECDH algorithm.
+     *
+     * @param alg The JWE ECDH algorithm. Must be supported and not
+     *            {@code null}.
+     * @param enc The encryption method. Must be supported} and not
+     *            {@code null}.
+     *
+     * @return The bit length of the shared key.
+     *
+     * @throws JOSEException If the JWE algorithm or encryption method is
+     *                       not supported.
+     */
+    public static int sharedKeyLength(final JWEAlgorithm alg, final EncryptionMethod enc)
+        throws JOSEException {
 
-		if (alg.equals(JWEAlgorithm.ECDH_1PU)) {
+        if (alg.equals(JWEAlgorithm.ECDH_1PU)) {
 
-			int length = enc.cekBitLength();
+            int length = enc.cekBitLength();
 
-			if (length == 0) {
-				throw new JOSEException("Unsupported JWE encryption method " + enc);
-			}
+            if (length == 0) {
+                throw new JOSEException("Unsupported JWE encryption method " + enc);
+            }
 
-			return length;
+            return length;
 
-		} else if (alg.equals(JWEAlgorithm.ECDH_1PU_A128KW)) {
-			return 128;
-		} else if (alg.equals(JWEAlgorithm.ECDH_1PU_A192KW)) {
-			return  192;
-		} else if (alg.equals(JWEAlgorithm.ECDH_1PU_A256KW)) {
-			return  256;
-		} else {
-			throw new JOSEException(AlgorithmSupportMessage.unsupportedJWEAlgorithm(
-				alg, ECDHCryptoProvider.SUPPORTED_ALGORITHMS));
-		}
-	}
+        } else if (alg.equals(JWEAlgorithm.ECDH_1PU_A128KW)) {
+            return 128;
+        } else if (alg.equals(JWEAlgorithm.ECDH_1PU_A192KW)) {
+            return  192;
+        } else if (alg.equals(JWEAlgorithm.ECDH_1PU_A256KW)) {
+            return  256;
+        } else {
+            throw new JOSEException(AlgorithmSupportMessage.unsupportedJWEAlgorithm(
+                alg, ECDHCryptoProvider.SUPPORTED_ALGORITHMS));
+        }
+    }
 
-	/**
-	 * Derives a shared key (via concat KDF).
-	 *
-	 * It should only be called in {@link ECDH.AlgorithmMode#DIRECT}
-	 * mode because shared key is cek and the tag is unknown.
-	 *
-	 * @param header    The JWE header. Its algorithm and encryption method
-	 *                  must be supported. Must not be {@code null}.
-	 * @param Z         The derived shared secret ('Z'). Must not be
-	 *                  {@code null}.
-	 * @param concatKDF The concat KDF. Must be initialised and not
-	 *                  {@code null}.
-	 *
-	 * @return The derived shared key.
-	 *
-	 * @throws JOSEException If derivation of the shared key failed.
-	 */
-	public static SecretKey deriveSharedKey(final JWEHeader header,
-											final SecretKey Z,
-											final ConcatKDF concatKDF)
-			throws JOSEException {
+    /**
+     * Derives a shared key (via concat KDF).
+     *
+     * It should only be called in {@link ECDH.AlgorithmMode#DIRECT}
+     * mode because shared key is cek and the tag is unknown.
+     *
+     * @param header    The JWE header. Its algorithm and encryption method
+     *                  must be supported. Must not be {@code null}.
+     * @param Z         The derived shared secret ('Z'). Must not be
+     *                  {@code null}.
+     * @param concatKDF The concat KDF. Must be initialised and not
+     *                  {@code null}.
+     *
+     * @return The derived shared key.
+     *
+     * @throws JOSEException If derivation of the shared key failed.
+     */
+    public static SecretKey deriveSharedKey(final JWEHeader header,
+                                            final SecretKey Z,
+                                            final ConcatKDF concatKDF)
+            throws JOSEException {
 
-		final int sharedKeyLength = sharedKeyLength(header.getAlgorithm(), header.getEncryptionMethod());
+        final int sharedKeyLength = sharedKeyLength(header.getAlgorithm(), header.getEncryptionMethod());
 
-		// Set the alg ID for the concat KDF
-		ECDH.AlgorithmMode algMode = resolveAlgorithmMode(header.getAlgorithm());
+        // Set the alg ID for the concat KDF
+        ECDH.AlgorithmMode algMode = resolveAlgorithmMode(header.getAlgorithm());
 
-		final String algID;
+        final String algID;
 
-		if (algMode == ECDH.AlgorithmMode.DIRECT) {
-			// algID = enc
-			algID = header.getEncryptionMethod().getName();
-		} else if (algMode == ECDH.AlgorithmMode.KW) {
-			// algID = alg
-			algID = header.getAlgorithm().getName();
-		} else {
-			throw new JOSEException("Unsupported JWE ECDH algorithm mode: " + algMode);
-		}
+        if (algMode == ECDH.AlgorithmMode.DIRECT) {
+            // algID = enc
+            algID = header.getEncryptionMethod().getName();
+        } else if (algMode == ECDH.AlgorithmMode.KW) {
+            // algID = alg
+            algID = header.getAlgorithm().getName();
+        } else {
+            throw new JOSEException("Unsupported JWE ECDH algorithm mode: " + algMode);
+        }
 
-		return concatKDF.deriveKey(
-				Z,
-				sharedKeyLength,
-				ConcatKDF.encodeDataWithLength(algID.getBytes(StandardCharsets.US_ASCII)),
-				ConcatKDF.encodeDataWithLength(header.getAgreementPartyUInfo()),
-				ConcatKDF.encodeDataWithLength(header.getAgreementPartyVInfo()),
-				ConcatKDF.encodeIntData(sharedKeyLength),
-				ConcatKDF.encodeNoData()
-		);
-	}
+        return concatKDF.deriveKey(
+                Z,
+                sharedKeyLength,
+                ConcatKDF.encodeDataWithLength(algID.getBytes(StandardCharsets.US_ASCII)),
+                ConcatKDF.encodeDataWithLength(header.getAgreementPartyUInfo()),
+                ConcatKDF.encodeDataWithLength(header.getAgreementPartyVInfo()),
+                ConcatKDF.encodeIntData(sharedKeyLength),
+                ConcatKDF.encodeNoData()
+        );
+    }
 
-	/**
-	 * Derives a shared key (via concat KDF).
-	 *
-	 * It should only be called in {@link ECDH.AlgorithmMode#KW}
-	 * mode the tag is known.
-	 *
-	 * @param header    The JWE header. Its algorithm and encryption method
-	 *                  must be supported. Must not be {@code null}.
-	 * @param Z         The derived shared secret ('Z'). Must not be
-	 *                  {@code null}.
-	 * @param tag       In Direct Key Agreement mode this is set to an empty octet
-	 *       			string. In Key Agreement with Key Wrapping mode, this is set to a
-	 *       			value of the form Data, where Data is the raw octets of
-	 *       			the JWE Authentication Tag.
-	 * @param concatKDF The concat KDF. Must be initialised and not
-	 *                  {@code null}.
-	 *
-	 * @return The derived shared key.
-	 *
-	 * @throws JOSEException If derivation of the shared key failed.
-	 */
-	public static SecretKey deriveSharedKey(final JWEHeader header,
-						final SecretKey Z,
-						final Base64URL tag,
-						final ConcatKDF concatKDF)
-		throws JOSEException {
+    /**
+     * Derives a shared key (via concat KDF).
+     *
+     * It should only be called in {@link ECDH.AlgorithmMode#KW}
+     * mode the tag is known.
+     *
+     * @param header    The JWE header. Its algorithm and encryption method
+     *                  must be supported. Must not be {@code null}.
+     * @param Z         The derived shared secret ('Z'). Must not be
+     *                  {@code null}.
+     * @param tag       In Direct Key Agreement mode this is set to an empty octet
+     *       			string. In Key Agreement with Key Wrapping mode, this is set to a
+     *       			value of the form Data, where Data is the raw octets of
+     *       			the JWE Authentication Tag.
+     * @param concatKDF The concat KDF. Must be initialised and not
+     *                  {@code null}.
+     *
+     * @return The derived shared key.
+     *
+     * @throws JOSEException If derivation of the shared key failed.
+     */
+    public static SecretKey deriveSharedKey(final JWEHeader header,
+                        final SecretKey Z,
+                        final Base64URL tag,
+                        final ConcatKDF concatKDF)
+        throws JOSEException {
 
-		final int sharedKeyLength = sharedKeyLength(header.getAlgorithm(), header.getEncryptionMethod());
+        final int sharedKeyLength = sharedKeyLength(header.getAlgorithm(), header.getEncryptionMethod());
 
-		// Set the alg ID for the concat KDF
-		ECDH.AlgorithmMode algMode = resolveAlgorithmMode(header.getAlgorithm());
+        // Set the alg ID for the concat KDF
+        ECDH.AlgorithmMode algMode = resolveAlgorithmMode(header.getAlgorithm());
 
-		final String algID;
+        final String algID;
 
-		if (algMode == ECDH.AlgorithmMode.DIRECT) {
-			// algID = enc
-			algID = header.getEncryptionMethod().getName();
-		} else if (algMode == ECDH.AlgorithmMode.KW) {
-			// algID = alg
-			algID = header.getAlgorithm().getName();
-		} else {
-			throw new JOSEException("Unsupported JWE ECDH algorithm mode: " + algMode);
-		}
+        if (algMode == ECDH.AlgorithmMode.DIRECT) {
+            // algID = enc
+            algID = header.getEncryptionMethod().getName();
+        } else if (algMode == ECDH.AlgorithmMode.KW) {
+            // algID = alg
+            algID = header.getAlgorithm().getName();
+        } else {
+            throw new JOSEException("Unsupported JWE ECDH algorithm mode: " + algMode);
+        }
 
-		return concatKDF.deriveKey(
-			Z,
-			sharedKeyLength,
-			ConcatKDF.encodeDataWithLength(algID.getBytes(StandardCharsets.US_ASCII)),
-			ConcatKDF.encodeDataWithLength(header.getAgreementPartyUInfo()),
-			ConcatKDF.encodeDataWithLength(header.getAgreementPartyVInfo()),
-			ConcatKDF.encodeIntData(sharedKeyLength),
-			ConcatKDF.encodeNoData(),
+        return concatKDF.deriveKey(
+            Z,
+            sharedKeyLength,
+            ConcatKDF.encodeDataWithLength(algID.getBytes(StandardCharsets.US_ASCII)),
+            ConcatKDF.encodeDataWithLength(header.getAgreementPartyUInfo()),
+            ConcatKDF.encodeDataWithLength(header.getAgreementPartyVInfo()),
+            ConcatKDF.encodeIntData(sharedKeyLength),
+            ConcatKDF.encodeNoData(),
             ConcatKDF.encodeDataWithLength(tag)
-		);
-	}
+        );
+    }
 
-	/**
-	 * Derives a shared secret (also called 'Z') where Z is the
-	 * concatenation of Ze and Zs.
-	 *
-	 * @param Ze	The shared secret derived from applying the ECDH primitive
-	 *              to the sender's ephemeral private key and the recipient's
-	 *              static public key (when sending) or the recipient's
-	 *              static private key and the sender's ephemeral public
-	 *       	 	key (when receiving) Must not be {@code null}.
-	 * @param Zs 	The shared secret derived from
-	 *       		applying the ECDH primitive to the sender's static private key and
-	 *       		the recipient's static public key (when sending) or the
-	 *       		recipient's static private key and the sender's static public key
-	 *       		(when receiving). Must not be {@code null}.
-	 * @return		The derived shared key.
-	 */
-	public static SecretKey deriveZ(final SecretKey Ze, final SecretKey Zs) {
-		byte[] encodedKey = ByteUtils.concat(Ze.getEncoded(), Zs.getEncoded());
-		return new SecretKeySpec(encodedKey, 0, encodedKey.length, "AES");
-	}
+    /**
+     * Derives a shared secret (also called 'Z') where Z is the
+     * concatenation of Ze and Zs.
+     *
+     * @param Ze	The shared secret derived from applying the ECDH primitive
+     *              to the sender's ephemeral private key and the recipient's
+     *              static public key (when sending) or the recipient's
+     *              static private key and the sender's ephemeral public
+     *       	 	key (when receiving) Must not be {@code null}.
+     * @param Zs 	The shared secret derived from
+     *       		applying the ECDH primitive to the sender's static private key and
+     *       		the recipient's static public key (when sending) or the
+     *       		recipient's static private key and the sender's static public key
+     *       		(when receiving). Must not be {@code null}.
+     * @return		The derived shared key.
+     */
+    public static SecretKey deriveZ(final SecretKey Ze, final SecretKey Zs) {
+        byte[] encodedKey = ByteUtils.concat(Ze.getEncoded(), Zs.getEncoded());
+        return new SecretKeySpec(encodedKey, 0, encodedKey.length, "AES");
+    }
 
 
-	/**
-	 * Check private key and public key are from the same curve
-	 *
-	 * @param privateKey EC private key
-	 * @param publicKey EC public key
-	 *
-	 * @throws JOSEException curves don't match
-	 *
-	 */
-	public static void validateSameCurve(ECPrivateKey privateKey, ECPublicKey publicKey) throws JOSEException{
-		if (!privateKey.getParams().getCurve().equals(publicKey.getParams().getCurve())) {
-			throw new JOSEException("Curve of public key does not match curve of private key");
-		}
+    /**
+     * Check private key and public key are from the same curve
+     *
+     * @param privateKey EC private key
+     * @param publicKey EC public key
+     *
+     * @throws JOSEException curves don't match
+     *
+     */
+    public static void validateSameCurve(ECPrivateKey privateKey, ECPublicKey publicKey) throws JOSEException{
+        if (!privateKey.getParams().getCurve().equals(publicKey.getParams().getCurve())) {
+            throw new JOSEException("Curve of public key does not match curve of private key");
+        }
 
-		if (!ECChecks.isPointOnCurve(publicKey, privateKey)) {
-			throw new JOSEException("Invalid public EC key: Point(s) not on the expected curve");
-		}
-	}
+        if (!ECChecks.isPointOnCurve(publicKey, privateKey)) {
+            throw new JOSEException("Invalid public EC key: Point(s) not on the expected curve");
+        }
+    }
 
-	/**
-	 * Check private key and public key are from the same curve
-	 *
-	 * @param privateKey OKP private key
-	 * @param publicKey OKP public key
-	 *
-	 * @throws JOSEException curves don't match
-	 */
-	public static void validateSameCurve(OctetKeyPair privateKey, OctetKeyPair publicKey) throws JOSEException {
-		if (!privateKey.isPrivate()) {
-			throw new JOSEException("OKP private key should be a private key");
-		}
+    /**
+     * Check private key and public key are from the same curve
+     *
+     * @param privateKey OKP private key
+     * @param publicKey OKP public key
+     *
+     * @throws JOSEException curves don't match
+     */
+    public static void validateSameCurve(OctetKeyPair privateKey, OctetKeyPair publicKey) throws JOSEException {
+        if (!privateKey.isPrivate()) {
+            throw new JOSEException("OKP private key should be a private key");
+        }
 
-		if (publicKey.isPrivate()) {
-			throw new JOSEException("OKP public key should not be a private key");
-		}
+        if (publicKey.isPrivate()) {
+            throw new JOSEException("OKP public key should not be a private key");
+        }
 
-		if (!publicKey.getCurve().equals(Curve.X25519)) {
-			throw new JOSEException("Only supports OctetKeyPairs with crv=X25519");
-		}
+        if (!publicKey.getCurve().equals(Curve.X25519)) {
+            throw new JOSEException("Only supports OctetKeyPairs with crv=X25519");
+        }
 
-		if (!privateKey.getCurve().equals(publicKey.getCurve())) {
-			throw new JOSEException("Curve of public key does not match curve of private key");
-		}
-	}
+        if (!privateKey.getCurve().equals(publicKey.getCurve())) {
+            throw new JOSEException("Curve of public key does not match curve of private key");
+        }
+    }
 
-	/**
-	 * Prevents public instantiation.
-	 */
-	private ECDH1PU() {
+    /**
+     * Prevents public instantiation.
+     */
+    private ECDH1PU() {
 
-	}
+    }
 }

--- a/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PU.java
+++ b/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PU.java
@@ -30,6 +30,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
+import java.util.Objects;
 
 
 /**
@@ -55,6 +56,8 @@ public class ECDH1PU {
      */
     public static ECDH.AlgorithmMode resolveAlgorithmMode(final JWEAlgorithm alg)
         throws JOSEException {
+
+        Objects.requireNonNull(alg, "The parameter \"alg\" must not be null");
 
         if (alg.equals(JWEAlgorithm.ECDH_1PU)) {
 
@@ -92,6 +95,9 @@ public class ECDH1PU {
     public static int sharedKeyLength(final JWEAlgorithm alg, final EncryptionMethod enc)
         throws JOSEException {
 
+        Objects.requireNonNull(alg, "The parameter \"alg\" must not be null");
+        Objects.requireNonNull(enc, "The parameter \"enc\" must not be null");
+
         if (alg.equals(JWEAlgorithm.ECDH_1PU)) {
 
             int length = enc.cekBitLength();
@@ -101,17 +107,22 @@ public class ECDH1PU {
             }
 
             return length;
-
-        } else if (alg.equals(JWEAlgorithm.ECDH_1PU_A128KW)) {
-            return 128;
-        } else if (alg.equals(JWEAlgorithm.ECDH_1PU_A192KW)) {
-            return  192;
-        } else if (alg.equals(JWEAlgorithm.ECDH_1PU_A256KW)) {
-            return  256;
-        } else {
-            throw new JOSEException(AlgorithmSupportMessage.unsupportedJWEAlgorithm(
-                alg, ECDHCryptoProvider.SUPPORTED_ALGORITHMS));
         }
+
+        if (alg.equals(JWEAlgorithm.ECDH_1PU_A128KW)) {
+            return 128;
+        }
+
+        if (alg.equals(JWEAlgorithm.ECDH_1PU_A192KW)) {
+            return  192;
+        }
+
+        if (alg.equals(JWEAlgorithm.ECDH_1PU_A256KW)) {
+            return  256;
+        }
+
+        throw new JOSEException(AlgorithmSupportMessage.unsupportedJWEAlgorithm(
+                alg, ECDHCryptoProvider.SUPPORTED_ALGORITHMS));
     }
 
     /**
@@ -140,6 +151,10 @@ public class ECDH1PU {
                                             final SecretKey Z,
                                             final ConcatKDF concatKDF)
             throws JOSEException {
+
+        Objects.requireNonNull(header, "The parameter \"header\" must not be null");
+        Objects.requireNonNull(Z, "The parameter \"Z\" must not be null");
+        Objects.requireNonNull(concatKDF, "The parameter \"concatKDF\" must not be null");
 
         final int sharedKeyLength = sharedKeyLength(header.getAlgorithm(), header.getEncryptionMethod());
 
@@ -201,6 +216,11 @@ public class ECDH1PU {
                         final ConcatKDF concatKDF)
         throws JOSEException {
 
+        Objects.requireNonNull(header, "The parameter \"header\" must not be null");
+        Objects.requireNonNull(Z, "The parameter \"Z\" must not be null");
+        Objects.requireNonNull(tag, "The parameter \"tag\" must not be null");
+        Objects.requireNonNull(concatKDF, "The parameter \"concatKDF\" must not be null");
+
         final int sharedKeyLength = sharedKeyLength(header.getAlgorithm(), header.getEncryptionMethod());
 
         // Set the alg ID for the concat KDF
@@ -247,6 +267,9 @@ public class ECDH1PU {
      * @return		The derived shared key.
      */
     public static SecretKey deriveZ(final SecretKey Ze, final SecretKey Zs) {
+        Objects.requireNonNull(Ze, "The parameter \"Ze\" must not be null");
+        Objects.requireNonNull(Zs, "The parameter \"Zs\" must not be null");
+
         byte[] encodedKey = ByteUtils.concat(Ze.getEncoded(), Zs.getEncoded());
         return new SecretKeySpec(encodedKey, 0, encodedKey.length, "AES");
     }
@@ -255,13 +278,16 @@ public class ECDH1PU {
     /**
      * Check private key and public key are from the same curve
      *
-     * @param privateKey EC private key
-     * @param publicKey EC public key
+     * @param privateKey EC private key. Must not be {@code null}.
+     * @param publicKey EC public key. Must not be {@code null}.
      *
      * @throws JOSEException curves don't match
      *
      */
     public static void validateSameCurve(ECPrivateKey privateKey, ECPublicKey publicKey) throws JOSEException{
+        Objects.requireNonNull(privateKey, "The parameter \"privateKey\" must not be null");
+        Objects.requireNonNull(publicKey, "The parameter \"publicKey\" must not be null");
+
         if (!privateKey.getParams().getCurve().equals(publicKey.getParams().getCurve())) {
             throw new JOSEException("Curve of public key does not match curve of private key");
         }
@@ -274,12 +300,15 @@ public class ECDH1PU {
     /**
      * Check private key and public key are from the same curve
      *
-     * @param privateKey OKP private key
-     * @param publicKey OKP public key
+     * @param privateKey OKP private key. Must not be {@code null}.
+     * @param publicKey OKP public key. Must not be {@code null}.
      *
      * @throws JOSEException curves don't match
      */
     public static void validateSameCurve(OctetKeyPair privateKey, OctetKeyPair publicKey) throws JOSEException {
+        Objects.requireNonNull(privateKey, "The parameter \"privateKey\" must not be null");
+        Objects.requireNonNull(publicKey, "The parameter \"publicKey\" must not be null");
+
         if (!privateKey.isPrivate()) {
             throw new JOSEException("OKP private key should be a private key");
         }

--- a/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PU.java
+++ b/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PU.java
@@ -117,8 +117,13 @@ public class ECDH1PU {
     /**
      * Derives a shared key (via concat KDF).
      *
-     * It should only be called in {@link ECDH.AlgorithmMode#DIRECT}
-     * mode because shared key is cek and the tag is unknown.
+     * The method should only be called in the {@link ECDH.AlgorithmMode#DIRECT} mode.
+     *
+     * The method derives the Content Encryption Key (CEK) for the "enc" algorithm,
+     * in the {@link ECDH.AlgorithmMode#DIRECT} mode.
+     *
+     * The method does not take the auth tag because the auth tag
+     * will be generated using a CEK derived as an output of this method.
      *
      * @param header    The JWE header. Its algorithm and encryption method
      *                  must be supported. Must not be {@code null}.
@@ -167,17 +172,22 @@ public class ECDH1PU {
     /**
      * Derives a shared key (via concat KDF).
      *
-     * It should only be called in {@link ECDH.AlgorithmMode#KW}
-     * mode the tag is known.
+     * The method should only be called in {@link ECDH.AlgorithmMode#KW}.
+     *
+     * In Key Agreement with {@link ECDH.AlgorithmMode#KW} mode,
+     * the JWE Authentication Tag is included in the input to the KDF.
+     * This ensures that the content of the JWE was produced by the original sender
+     * and not by another recipient.
+     *
      *
      * @param header    The JWE header. Its algorithm and encryption method
      *                  must be supported. Must not be {@code null}.
      * @param Z         The derived shared secret ('Z'). Must not be
      *                  {@code null}.
      * @param tag       In Direct Key Agreement mode this is set to an empty octet
-     *       			string. In Key Agreement with Key Wrapping mode, this is set to a
-     *       			value of the form Data, where Data is the raw octets of
-     *       			the JWE Authentication Tag.
+     *                  string. In Key Agreement with Key Wrapping mode, this is set to a
+     *                  value of the form Data, where Data is the raw octets of
+     *                  the JWE Authentication Tag.
      * @param concatKDF The concat KDF. Must be initialised and not
      *                  {@code null}.
      *

--- a/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PU.java
+++ b/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PU.java
@@ -59,19 +59,19 @@ public class ECDH1PU {
         if (alg.equals(JWEAlgorithm.ECDH_1PU)) {
 
             return ECDH.AlgorithmMode.DIRECT;
+        }
 
-        } else if (alg.equals(JWEAlgorithm.ECDH_1PU_A128KW) ||
+        if (alg.equals(JWEAlgorithm.ECDH_1PU_A128KW) ||
                 alg.equals(JWEAlgorithm.ECDH_1PU_A192KW) ||
                 alg.equals(JWEAlgorithm.ECDH_1PU_A256KW)
         ) {
 
             return ECDH.AlgorithmMode.KW;
-        } else {
+        }
 
-            throw new JOSEException(AlgorithmSupportMessage.unsupportedJWEAlgorithm(
+        throw new JOSEException(AlgorithmSupportMessage.unsupportedJWEAlgorithm(
                 alg,
                 ECDHCryptoProvider.SUPPORTED_ALGORITHMS));
-        }
     }
 
 
@@ -81,7 +81,7 @@ public class ECDH1PU {
      *
      * @param alg The JWE ECDH algorithm. Must be supported and not
      *            {@code null}.
-     * @param enc The encryption method. Must be supported} and not
+     * @param enc The encryption method. Must be supported and not
      *            {@code null}.
      *
      * @return The bit length of the shared key.

--- a/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PUCryptoProvider.java
+++ b/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PUCryptoProvider.java
@@ -77,194 +77,194 @@ import java.util.Set;
 public abstract class ECDH1PUCryptoProvider extends BaseJWEProvider {
 
 
-	/**
-	 * The supported JWE algorithms by the ECDH crypto provider class.
-	 */
-	public static final Set<JWEAlgorithm> SUPPORTED_ALGORITHMS;
+    /**
+     * The supported JWE algorithms by the ECDH crypto provider class.
+     */
+    public static final Set<JWEAlgorithm> SUPPORTED_ALGORITHMS;
 
 
-	/**
-	 * The supported encryption methods by the ECDH crypto provider class.
-	 */
-	public static final Set<EncryptionMethod> SUPPORTED_ENCRYPTION_METHODS = ContentCryptoProvider.SUPPORTED_ENCRYPTION_METHODS;
+    /**
+     * The supported encryption methods by the ECDH crypto provider class.
+     */
+    public static final Set<EncryptionMethod> SUPPORTED_ENCRYPTION_METHODS = ContentCryptoProvider.SUPPORTED_ENCRYPTION_METHODS;
 
 
-	static {
-		Set<JWEAlgorithm> algs = new LinkedHashSet<>();
-		algs.add(JWEAlgorithm.ECDH_1PU);
-		algs.add(JWEAlgorithm.ECDH_1PU_A128KW);
-		algs.add(JWEAlgorithm.ECDH_1PU_A192KW);
-		algs.add(JWEAlgorithm.ECDH_1PU_A256KW);
-		SUPPORTED_ALGORITHMS = Collections.unmodifiableSet(algs);
-	}
+    static {
+        Set<JWEAlgorithm> algs = new LinkedHashSet<>();
+        algs.add(JWEAlgorithm.ECDH_1PU);
+        algs.add(JWEAlgorithm.ECDH_1PU_A128KW);
+        algs.add(JWEAlgorithm.ECDH_1PU_A192KW);
+        algs.add(JWEAlgorithm.ECDH_1PU_A256KW);
+        SUPPORTED_ALGORITHMS = Collections.unmodifiableSet(algs);
+    }
 
 
-	/**
-	 * The elliptic curve.
-	 */
-	private final Curve curve;
+    /**
+     * The elliptic curve.
+     */
+    private final Curve curve;
 
 
-	/**
-	 * The Concatenation Key Derivation Function (KDF).
-	 */
-	private final ConcatKDF concatKDF;
+    /**
+     * The Concatenation Key Derivation Function (KDF).
+     */
+    private final ConcatKDF concatKDF;
 
 
-	/**
-	 * Creates a new Elliptic Curve Diffie-Hellman One-Pass Unified Model
-	 * encryption / decryption provider.
-	 *
-	 * @param curve The elliptic curve. Must be supported and not
-	 *              {@code null}.
-	 *
-	 * @throws JOSEException If the elliptic curve is not supported.
-	 */
-	protected ECDH1PUCryptoProvider(final Curve curve)
-		throws JOSEException {
+    /**
+     * Creates a new Elliptic Curve Diffie-Hellman One-Pass Unified Model
+     * encryption / decryption provider.
+     *
+     * @param curve The elliptic curve. Must be supported and not
+     *              {@code null}.
+     *
+     * @throws JOSEException If the elliptic curve is not supported.
+     */
+    protected ECDH1PUCryptoProvider(final Curve curve)
+        throws JOSEException {
 
-		super(SUPPORTED_ALGORITHMS, ContentCryptoProvider.SUPPORTED_ENCRYPTION_METHODS);
+        super(SUPPORTED_ALGORITHMS, ContentCryptoProvider.SUPPORTED_ENCRYPTION_METHODS);
 
-		Curve definedCurve = curve != null ? curve : new Curve("unknown");
+        Curve definedCurve = curve != null ? curve : new Curve("unknown");
 
-		if (! supportedEllipticCurves().contains(curve)) {
-			throw new JOSEException(AlgorithmSupportMessage.unsupportedEllipticCurve(
-				definedCurve, supportedEllipticCurves()));
-		}
+        if (! supportedEllipticCurves().contains(curve)) {
+            throw new JOSEException(AlgorithmSupportMessage.unsupportedEllipticCurve(
+                definedCurve, supportedEllipticCurves()));
+        }
 
-		this.curve = curve;
+        this.curve = curve;
 
-		concatKDF = new ConcatKDF("SHA-256");
-	}
-
-
-	/**
-	 * Returns the Concatenation Key Derivation Function (KDF).
-	 *
-	 * @return The concat KDF.
-	 */
-	protected ConcatKDF getConcatKDF() {
-
-		return concatKDF;
-	}
+        concatKDF = new ConcatKDF("SHA-256");
+    }
 
 
-	/**
-	 * Returns the names of the supported elliptic curves. These correspond
-	 * to the {@code crv} EC JWK parameter.
-	 *
-	 * @return The supported elliptic curves.
-	 */
-	public abstract Set<Curve> supportedEllipticCurves();
+    /**
+     * Returns the Concatenation Key Derivation Function (KDF).
+     *
+     * @return The concat KDF.
+     */
+    protected ConcatKDF getConcatKDF() {
+
+        return concatKDF;
+    }
 
 
-	/**
-	 * Returns the elliptic curve of the key (JWK designation).
-	 *
-	 * @return The elliptic curve.
-	 */
-	public Curve getCurve() {
+    /**
+     * Returns the names of the supported elliptic curves. These correspond
+     * to the {@code crv} EC JWK parameter.
+     *
+     * @return The supported elliptic curves.
+     */
+    public abstract Set<Curve> supportedEllipticCurves();
 
-		return curve;
-	}
 
-	/**
-	 * Encrypts the specified plaintext using the specified shared secret
-	 * ("Z") and, if provided, the content encryption key (CEK).
-	 */
-	protected JWECryptoParts encryptWithZ(final JWEHeader header,
-					      final SecretKey Z,
-					      final byte[] clearText,
-					      final SecretKey contentEncryptionKey)
-		throws JOSEException {
+    /**
+     * Returns the elliptic curve of the key (JWK designation).
+     *
+     * @return The elliptic curve.
+     */
+    public Curve getCurve() {
 
-		final JWEAlgorithm alg = header.getAlgorithm();
-		final ECDH.AlgorithmMode algMode = ECDH1PU.resolveAlgorithmMode(alg);
-		final EncryptionMethod enc = header.getEncryptionMethod();
+        return curve;
+    }
 
-		final SecretKey cek;
-		final Base64URL encryptedKey; // The CEK encrypted (second JWE part)
+    /**
+     * Encrypts the specified plaintext using the specified shared secret
+     * ("Z") and, if provided, the content encryption key (CEK).
+     */
+    protected JWECryptoParts encryptWithZ(final JWEHeader header,
+                          final SecretKey Z,
+                          final byte[] clearText,
+                          final SecretKey contentEncryptionKey)
+        throws JOSEException {
 
-		if (algMode.equals(ECDH.AlgorithmMode.DIRECT)) {
+        final JWEAlgorithm alg = header.getAlgorithm();
+        final ECDH.AlgorithmMode algMode = ECDH1PU.resolveAlgorithmMode(alg);
+        final EncryptionMethod enc = header.getEncryptionMethod();
 
-			// Derive shared key via concat KDF
-			getConcatKDF().getJCAContext().setProvider(getJCAContext().getMACProvider()); // update before concat
-			cek = ECDH1PU.deriveSharedKey(header, Z, getConcatKDF());
+        final SecretKey cek;
+        final Base64URL encryptedKey; // The CEK encrypted (second JWE part)
 
-			return ContentCryptoProvider.encrypt(header, clearText, cek, null, getJCAContext());
-		}
+        if (algMode.equals(ECDH.AlgorithmMode.DIRECT)) {
 
-		if (algMode.equals(ECDH.AlgorithmMode.KW)) {
+            // Derive shared key via concat KDF
+            getConcatKDF().getJCAContext().setProvider(getJCAContext().getMACProvider()); // update before concat
+            cek = ECDH1PU.deriveSharedKey(header, Z, getConcatKDF());
 
-			// Key wrapping mode supports only AES_CBC_HMAC_SHA2
-			// See https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#section-2.1
-			if (!EncryptionMethod.Family.AES_CBC_HMAC_SHA.contains(enc)) {
-				throw new JOSEException(AlgorithmSupportMessage.unsupportedEncryptionMethod(
-						header.getEncryptionMethod(),
-						EncryptionMethod.Family.AES_CBC_HMAC_SHA));
-			}
+            return ContentCryptoProvider.encrypt(header, clearText, cek, null, getJCAContext());
+        }
 
-			if (contentEncryptionKey != null) { // Use externally supplied CEK
-				cek = contentEncryptionKey;
-			} else { // Generate the CEK according to the enc method
-				cek = ContentCryptoProvider.generateCEK(enc, getJCAContext().getSecureRandom());
-			}
+        if (algMode.equals(ECDH.AlgorithmMode.KW)) {
 
-			JWECryptoParts encrypted = ContentCryptoProvider.encrypt(header, clearText, cek, null, getJCAContext());
+            // Key wrapping mode supports only AES_CBC_HMAC_SHA2
+            // See https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#section-2.1
+            if (!EncryptionMethod.Family.AES_CBC_HMAC_SHA.contains(enc)) {
+                throw new JOSEException(AlgorithmSupportMessage.unsupportedEncryptionMethod(
+                        header.getEncryptionMethod(),
+                        EncryptionMethod.Family.AES_CBC_HMAC_SHA));
+            }
 
-			SecretKey sharedKey = ECDH1PU.deriveSharedKey(header, Z, encrypted.getAuthenticationTag(), getConcatKDF());
-			encryptedKey = Base64URL.encode(AESKW.wrapCEK(cek, sharedKey, getJCAContext().getKeyEncryptionProvider()));
+            if (contentEncryptionKey != null) { // Use externally supplied CEK
+                cek = contentEncryptionKey;
+            } else { // Generate the CEK according to the enc method
+                cek = ContentCryptoProvider.generateCEK(enc, getJCAContext().getSecureRandom());
+            }
 
-			return new JWECryptoParts(
-					header,
-					encryptedKey,
-					encrypted.getInitializationVector(),
-					encrypted.getCipherText(),
-					encrypted.getAuthenticationTag()
-			);
-		}
+            JWECryptoParts encrypted = ContentCryptoProvider.encrypt(header, clearText, cek, null, getJCAContext());
 
-		throw new JOSEException("Unexpected JWE ECDH algorithm mode: " + algMode);
-	}
+            SecretKey sharedKey = ECDH1PU.deriveSharedKey(header, Z, encrypted.getAuthenticationTag(), getConcatKDF());
+            encryptedKey = Base64URL.encode(AESKW.wrapCEK(cek, sharedKey, getJCAContext().getKeyEncryptionProvider()));
 
-	/**
-	 * Decrypts the encrypted JWE parts using the specified shared secret ("Z").
-	 */
-	protected byte[] decryptWithZ(final JWEHeader header,
-				      final SecretKey Z,
-				      final Base64URL encryptedKey,
-				      final Base64URL iv,
-				      final Base64URL cipherText,
-				      final Base64URL authTag)
-		throws JOSEException {
+            return new JWECryptoParts(
+                    header,
+                    encryptedKey,
+                    encrypted.getInitializationVector(),
+                    encrypted.getCipherText(),
+                    encrypted.getAuthenticationTag()
+            );
+        }
 
-		final JWEAlgorithm alg = header.getAlgorithm();
-		final ECDH.AlgorithmMode algMode = ECDH1PU.resolveAlgorithmMode(alg);
+        throw new JOSEException("Unexpected JWE ECDH algorithm mode: " + algMode);
+    }
 
-		// Derive shared key via concat KDF
-		getConcatKDF().getJCAContext().setProvider(getJCAContext().getMACProvider()); // update before concat
+    /**
+     * Decrypts the encrypted JWE parts using the specified shared secret ("Z").
+     */
+    protected byte[] decryptWithZ(final JWEHeader header,
+                      final SecretKey Z,
+                      final Base64URL encryptedKey,
+                      final Base64URL iv,
+                      final Base64URL cipherText,
+                      final Base64URL authTag)
+        throws JOSEException {
 
-		JWEHeader updatedHeader = new JWEHeader.Builder(header).
-				iv(iv).
-				authTag(authTag).
-				build();
+        final JWEAlgorithm alg = header.getAlgorithm();
+        final ECDH.AlgorithmMode algMode = ECDH1PU.resolveAlgorithmMode(alg);
 
-		final SecretKey cek;
+        // Derive shared key via concat KDF
+        getConcatKDF().getJCAContext().setProvider(getJCAContext().getMACProvider()); // update before concat
 
-		if (algMode.equals(ECDH.AlgorithmMode.DIRECT)) {
-			cek = ECDH1PU.deriveSharedKey(updatedHeader, Z, getConcatKDF());
-		} else if (algMode.equals(ECDH.AlgorithmMode.KW)) {
-			if (encryptedKey == null) {
-				throw new JOSEException("Missing JWE encrypted key");
-			}
+        JWEHeader updatedHeader = new JWEHeader.Builder(header).
+                iv(iv).
+                authTag(authTag).
+                build();
 
-			SecretKey sharedKey = ECDH1PU.deriveSharedKey(updatedHeader, Z, authTag, getConcatKDF());
-			cek = AESKW.unwrapCEK(sharedKey, encryptedKey.decode(), getJCAContext().getKeyEncryptionProvider());
-		} else {
-			throw new JOSEException("Unexpected JWE ECDH algorithm mode: " + algMode);
-		}
+        final SecretKey cek;
 
-		return ContentCryptoProvider.decrypt(header, encryptedKey, iv, cipherText, authTag, cek, getJCAContext());
-	}
+        if (algMode.equals(ECDH.AlgorithmMode.DIRECT)) {
+            cek = ECDH1PU.deriveSharedKey(updatedHeader, Z, getConcatKDF());
+        } else if (algMode.equals(ECDH.AlgorithmMode.KW)) {
+            if (encryptedKey == null) {
+                throw new JOSEException("Missing JWE encrypted key");
+            }
+
+            SecretKey sharedKey = ECDH1PU.deriveSharedKey(updatedHeader, Z, authTag, getConcatKDF());
+            cek = AESKW.unwrapCEK(sharedKey, encryptedKey.decode(), getJCAContext().getKeyEncryptionProvider());
+        } else {
+            throw new JOSEException("Unexpected JWE ECDH algorithm mode: " + algMode);
+        }
+
+        return ContentCryptoProvider.decrypt(header, encryptedKey, iv, cipherText, authTag, cek, getJCAContext());
+    }
 
 }

--- a/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PUCryptoProvider.java
+++ b/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PUCryptoProvider.java
@@ -170,7 +170,10 @@ public abstract class ECDH1PUCryptoProvider extends BaseJWEProvider {
 
     /**
      * Encrypts the specified plaintext using the specified shared secret
-     * ("Z") and, if provided, the content encryption key (CEK).
+     * ("Z").
+     *
+     * Encrypts the specified plaintext using if provided,
+     * the content encryption key (CEK) for {@link ECDH.AlgorithmMode#KW}.
      */
     protected JWECryptoParts encryptWithZ(final JWEHeader header,
                                           final SecretKey Z,

--- a/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PUCryptoProvider.java
+++ b/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PUCryptoProvider.java
@@ -127,7 +127,7 @@ public abstract class ECDH1PUCryptoProvider extends BaseJWEProvider {
 
         Curve definedCurve = curve != null ? curve : new Curve("unknown");
 
-        if (! supportedEllipticCurves().contains(curve)) {
+        if (!supportedEllipticCurves().contains(curve)) {
             throw new JOSEException(AlgorithmSupportMessage.unsupportedEllipticCurve(
                 definedCurve, supportedEllipticCurves()));
         }
@@ -173,9 +173,9 @@ public abstract class ECDH1PUCryptoProvider extends BaseJWEProvider {
      * ("Z") and, if provided, the content encryption key (CEK).
      */
     protected JWECryptoParts encryptWithZ(final JWEHeader header,
-                          final SecretKey Z,
-                          final byte[] clearText,
-                          final SecretKey contentEncryptionKey)
+                                          final SecretKey Z,
+                                          final byte[] clearText,
+                                          final SecretKey contentEncryptionKey)
         throws JOSEException {
 
         final JWEAlgorithm alg = header.getAlgorithm();
@@ -231,11 +231,11 @@ public abstract class ECDH1PUCryptoProvider extends BaseJWEProvider {
      * Decrypts the encrypted JWE parts using the specified shared secret ("Z").
      */
     protected byte[] decryptWithZ(final JWEHeader header,
-                      final SecretKey Z,
-                      final Base64URL encryptedKey,
-                      final Base64URL iv,
-                      final Base64URL cipherText,
-                      final Base64URL authTag)
+                                  final SecretKey Z,
+                                  final Base64URL encryptedKey,
+                                  final Base64URL iv,
+                                  final Base64URL cipherText,
+                                  final Base64URL authTag)
         throws JOSEException {
 
         final JWEAlgorithm alg = header.getAlgorithm();
@@ -264,7 +264,7 @@ public abstract class ECDH1PUCryptoProvider extends BaseJWEProvider {
             throw new JOSEException("Unexpected JWE ECDH algorithm mode: " + algMode);
         }
 
-        return ContentCryptoProvider.decrypt(header, encryptedKey, iv, cipherText, authTag, cek, getJCAContext());
+        return ContentCryptoProvider.decrypt(header, null, iv, cipherText, authTag, cek, getJCAContext());
     }
 
 }

--- a/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PUCryptoProvider.java
+++ b/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PUCryptoProvider.java
@@ -63,7 +63,7 @@ import java.util.Set;
  *     <li>{@link com.nimbusds.jose.EncryptionMethod#A256CBC_HS512_DEPRECATED}
  * </ul>
  *
- * <p>Supports the following content encryption algorithms for Direct Key wrapping mode:
+ * <p>Supports the following content encryption algorithms for Key wrapping mode:
  *
  * <ul>
  *     <li>{@link com.nimbusds.jose.EncryptionMethod#A128CBC_HS256}

--- a/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PUCryptoProvider.java
+++ b/src/main/java/com/nimbusds/jose/crypto/impl/ECDH1PUCryptoProvider.java
@@ -1,0 +1,260 @@
+/*
+ * nimbus-jose-jwt
+ *
+ * Copyright 2012-2019, Connect2id Ltd and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.nimbusds.jose.crypto.impl;
+
+
+import com.nimbusds.jose.*;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.util.Base64URL;
+
+import javax.crypto.SecretKey;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+
+/**
+ * The base abstract class for Elliptic Curve Diffie-Hellman One-Pass Unified Model
+ * encrypters and decrypters of {@link com.nimbusds.jose.JWEObject JWE objects}.
+ *
+ * <p>Supports the following key management algorithms:
+ *
+ * <ul>
+ *     <li>{@link JWEAlgorithm#ECDH_1PU}
+ *     <li>{@link JWEAlgorithm#ECDH_1PU_A128KW}
+ *     <li>{@link JWEAlgorithm#ECDH_1PU_A192KW}
+ *     <li>{@link JWEAlgorithm#ECDH_1PU_A256KW}
+ * </ul>
+ *
+ * <p>Supports the following elliptic curves:
+ *
+ * <ul>
+ *     <li>{@link Curve#P_256}
+ *     <li>{@link Curve#P_384}
+ *     <li>{@link Curve#P_521}
+ *     <li>{@link Curve#X25519}
+ * </ul>
+ *
+ * <p>Supports the following content encryption algorithms:
+ *
+ * <ul>
+ *     <li>{@link EncryptionMethod#A128CBC_HS256}
+ *     <li>{@link EncryptionMethod#A192CBC_HS384}
+ *     <li>{@link EncryptionMethod#A256CBC_HS512}
+ * </ul>
+ *
+ * @author Alexander Martynov
+ * @version 2021-08-03
+ */
+public abstract class ECDH1PUCryptoProvider extends BaseJWEProvider {
+
+
+	/**
+	 * The supported JWE algorithms by the ECDH crypto provider class.
+	 */
+	public static final Set<JWEAlgorithm> SUPPORTED_ALGORITHMS;
+
+
+	/**
+	 * The supported encryption methods by the ECDH crypto provider class.
+	 */
+	public static final Set<EncryptionMethod> SUPPORTED_ENCRYPTION_METHODS = ContentCryptoProvider.SUPPORTED_ENCRYPTION_METHODS;
+
+
+	static {
+		Set<JWEAlgorithm> algs = new LinkedHashSet<>();
+		algs.add(JWEAlgorithm.ECDH_1PU);
+		algs.add(JWEAlgorithm.ECDH_1PU_A128KW);
+		algs.add(JWEAlgorithm.ECDH_1PU_A192KW);
+		algs.add(JWEAlgorithm.ECDH_1PU_A256KW);
+		SUPPORTED_ALGORITHMS = Collections.unmodifiableSet(algs);
+	}
+
+
+	/**
+	 * The elliptic curve.
+	 */
+	private final Curve curve;
+
+
+	/**
+	 * The Concatenation Key Derivation Function (KDF).
+	 */
+	private final ConcatKDF concatKDF;
+
+
+	/**
+	 * Creates a new Elliptic Curve Diffie-Hellman One-Pass Unified Model
+	 * encryption / decryption provider.
+	 *
+	 * @param curve The elliptic curve. Must be supported and not
+	 *              {@code null}.
+	 *
+	 * @throws JOSEException If the elliptic curve is not supported.
+	 */
+	protected ECDH1PUCryptoProvider(final Curve curve)
+		throws JOSEException {
+
+		super(SUPPORTED_ALGORITHMS, ContentCryptoProvider.SUPPORTED_ENCRYPTION_METHODS);
+
+		Curve definedCurve = curve != null ? curve : new Curve("unknown");
+
+		if (! supportedEllipticCurves().contains(curve)) {
+			throw new JOSEException(AlgorithmSupportMessage.unsupportedEllipticCurve(
+				definedCurve, supportedEllipticCurves()));
+		}
+
+		this.curve = curve;
+
+		concatKDF = new ConcatKDF("SHA-256");
+	}
+
+
+	/**
+	 * Returns the Concatenation Key Derivation Function (KDF).
+	 *
+	 * @return The concat KDF.
+	 */
+	protected ConcatKDF getConcatKDF() {
+
+		return concatKDF;
+	}
+
+
+	/**
+	 * Returns the names of the supported elliptic curves. These correspond
+	 * to the {@code crv} EC JWK parameter.
+	 *
+	 * @return The supported elliptic curves.
+	 */
+	public abstract Set<Curve> supportedEllipticCurves();
+
+
+	/**
+	 * Returns the elliptic curve of the key (JWK designation).
+	 *
+	 * @return The elliptic curve.
+	 */
+	public Curve getCurve() {
+
+		return curve;
+	}
+
+	/**
+	 * Encrypts the specified plaintext using the specified shared secret
+	 * ("Z").
+	 */
+	protected JWECryptoParts encryptWithZ(final JWEHeader header, final SecretKey Z, final byte[] clearText)
+		throws JOSEException {
+		
+		return this.encryptWithZ(header, Z, clearText, null);
+	}
+
+	/**
+	 * Encrypts the specified plaintext using the specified shared secret
+	 * ("Z") and, if provided, the content encryption key (CEK).
+	 */
+	protected JWECryptoParts encryptWithZ(final JWEHeader header,
+					      final SecretKey Z,
+					      final byte[] clearText,
+					      final SecretKey contentEncryptionKey)
+		throws JOSEException {
+
+		final JWEAlgorithm alg = header.getAlgorithm();
+		final ECDH.AlgorithmMode algMode = ECDH1PU.resolveAlgorithmMode(alg);
+		final EncryptionMethod enc = header.getEncryptionMethod();
+
+		final SecretKey cek;
+		final Base64URL encryptedKey; // The CEK encrypted (second JWE part)
+
+		if (algMode.equals(ECDH.AlgorithmMode.DIRECT)) {
+
+			// Derive shared key via concat KDF
+			getConcatKDF().getJCAContext().setProvider(getJCAContext().getMACProvider()); // update before concat
+			cek = ECDH1PU.deriveSharedKey(header, Z, getConcatKDF());
+
+			return ContentCryptoProvider.encrypt(header, clearText, cek, null, getJCAContext());
+		}
+
+		if (algMode.equals(ECDH.AlgorithmMode.KW)) {
+
+			if(contentEncryptionKey != null) { // Use externally supplied CEK
+				cek = contentEncryptionKey;
+			} else { // Generate the CEK according to the enc method
+				cek = ContentCryptoProvider.generateCEK(enc, getJCAContext().getSecureRandom());
+			}
+
+			JWECryptoParts encrypted = ContentCryptoProvider.encrypt(header, clearText, cek, null, getJCAContext());
+
+			SecretKey sharedKey = ECDH1PU.deriveSharedKey(header, Z, encrypted.getAuthenticationTag(), getConcatKDF());
+			encryptedKey = Base64URL.encode(AESKW.wrapCEK(cek, sharedKey, getJCAContext().getKeyEncryptionProvider()));
+
+			return new JWECryptoParts(
+					header,
+					encryptedKey,
+					encrypted.getInitializationVector(),
+					encrypted.getCipherText(),
+					encrypted.getAuthenticationTag()
+			);
+		}
+
+		throw new JOSEException("Unexpected JWE ECDH algorithm mode: " + algMode);
+	}
+
+	/**
+	 * Decrypts the encrypted JWE parts using the specified shared secret ("Z").
+	 */
+	protected byte[] decryptWithZ(final JWEHeader header,
+				      final SecretKey Z,
+				      final Base64URL encryptedKey,
+				      final Base64URL iv,
+				      final Base64URL cipherText,
+				      final Base64URL authTag)
+		throws JOSEException {
+
+		final JWEAlgorithm alg = header.getAlgorithm();
+		final ECDH.AlgorithmMode algMode = ECDH1PU.resolveAlgorithmMode(alg);
+
+		// Derive shared key via concat KDF
+		getConcatKDF().getJCAContext().setProvider(getJCAContext().getMACProvider()); // update before concat
+
+		JWEHeader updatedHeader = new JWEHeader.Builder(header).
+				iv(iv).
+				authTag(authTag).
+				build();
+
+		final SecretKey cek;
+
+		if (algMode.equals(ECDH.AlgorithmMode.DIRECT)) {
+			cek = ECDH1PU.deriveSharedKey(updatedHeader, Z, getConcatKDF());
+		} else if (algMode.equals(ECDH.AlgorithmMode.KW)) {
+			if (encryptedKey == null) {
+				throw new JOSEException("Missing JWE encrypted key");
+			}
+
+			SecretKey sharedKey = ECDH1PU.deriveSharedKey(updatedHeader, Z, authTag, getConcatKDF());
+			cek = AESKW.unwrapCEK(sharedKey, encryptedKey.decode(), getJCAContext().getKeyEncryptionProvider());
+		} else {
+			throw new JOSEException("Unexpected JWE ECDH algorithm mode: " + algMode);
+		}
+
+		return ContentCryptoProvider.decrypt(header, encryptedKey, iv, cipherText, authTag, cek, getJCAContext());
+	}
+
+
+}

--- a/src/test/java/com/nimbusds/jose/crypto/ECDH1PUCryptoTest.java
+++ b/src/test/java/com/nimbusds/jose/crypto/ECDH1PUCryptoTest.java
@@ -1,0 +1,375 @@
+/*
+ * nimbus-jose-jwt
+ *
+ * Copyright 2012-2019, Connect2id Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.nimbusds.jose.crypto;
+
+
+import com.nimbusds.jose.*;
+import com.nimbusds.jose.crypto.bc.BouncyCastleProviderSingleton;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.util.Base64URL;
+import junit.framework.TestCase;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
+import java.util.Collections;
+import java.util.HashSet;
+
+
+/**
+ * Tests ECDH-1PU encryption and decryption.
+ *
+ * @author Alexander Martynov
+ * @version 2021-08-04
+ */
+public class ECDH1PUCryptoTest extends TestCase {
+
+
+	private static ECKey generateECJWK(final Curve curve)
+		throws Exception {
+
+		ECParameterSpec ecParameterSpec = curve.toECParameterSpec();
+
+		KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
+		generator.initialize(ecParameterSpec);
+		KeyPair keyPair = generator.generateKeyPair();
+
+		return new ECKey.Builder(curve, (ECPublicKey)keyPair.getPublic()).
+			privateKey((ECPrivateKey) keyPair.getPrivate()).
+			build();
+	}
+
+
+	public void testCycle_ECDH_1PU_Curve_P256()
+		throws Exception {
+
+		ECKey aliceKey = generateECJWK(Curve.P_256);
+		ECKey bobKey = generateECJWK(Curve.P_256);
+
+		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128GCM).
+			agreementPartyUInfo(Base64URL.encode("Alice")).
+			agreementPartyVInfo(Base64URL.encode("Bob")).
+			build();
+
+		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+
+		ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey());
+		encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+		jweObject.encrypt(encrypter);
+
+		ECKey epk = (ECKey) jweObject.getHeader().getEphemeralPublicKey();
+		assertEquals(Curve.P_256, epk.getCurve());
+		assertNotNull(epk.getX());
+		assertNotNull(epk.getY());
+		assertNull(epk.getD());
+
+		assertNull(jweObject.getEncryptedKey());
+
+		String jwe = jweObject.serialize();
+
+		jweObject = JWEObject.parse(jwe);
+
+		ECDH1PUDecrypter decrypter = new ECDH1PUDecrypter(bobKey.toECPrivateKey(), aliceKey.toECPublicKey());
+		decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+		jweObject.decrypt(decrypter);
+
+		assertEquals("Hello world!", jweObject.getPayload().toString());
+	}
+
+
+	public void testCycle_ECDH_1PU_Curve_P256_A128KW()
+		throws Exception {
+
+		ECKey aliceKey = generateECJWK(Curve.P_256);
+		ECKey bobKey = generateECJWK(Curve.P_256);
+
+		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU_A128KW, EncryptionMethod.A256CBC_HS512).
+			agreementPartyUInfo(Base64URL.encode("Alice")).
+			agreementPartyVInfo(Base64URL.encode("Bob")).
+			build();
+
+		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+
+		ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey());
+		encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+		jweObject.encrypt(encrypter);
+
+		ECKey epk = (ECKey) jweObject.getHeader().getEphemeralPublicKey();
+		assertEquals(Curve.P_256, epk.getCurve());
+		assertNotNull(epk.getX());
+		assertNotNull(epk.getY());
+		assertNull(epk.getD());
+
+		assertNotNull(jweObject.getEncryptedKey());
+
+		String jwe = jweObject.serialize();
+
+		jweObject = JWEObject.parse(jwe);
+
+		ECDH1PUDecrypter decrypter = new ECDH1PUDecrypter(bobKey.toECPrivateKey(), aliceKey.toECPublicKey());
+		decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+		jweObject.decrypt(decrypter);
+
+		assertEquals("Hello world!", jweObject.getPayload().toString());
+	}
+	
+	/**
+	 * Test ECDH Encrypter with provided CEK encryption and decryption cycle.
+	 * 
+	 * @throws Exception
+	 */
+	public void testCycle_ECDH_1PU_Curve_P256_A128KW_WithCekSpecified() throws Exception {
+		ECKey aliceKey = generateECJWK(Curve.P_256);
+		ECKey bobKey = generateECJWK(Curve.P_256);
+
+		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU_A128KW, EncryptionMethod.A128GCM).
+				agreementPartyUInfo(Base64URL.encode("Alice")).
+				agreementPartyVInfo(Base64URL.encode("Bob")).
+				build();
+
+		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+
+		KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+		keyGenerator.init(EncryptionMethod.A128GCM.cekBitLength());
+		SecretKey cek = keyGenerator.generateKey();
+
+		ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey(), cek);
+		encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+		jweObject.encrypt(encrypter);
+
+		ECKey epk = (ECKey) jweObject.getHeader().getEphemeralPublicKey();
+		assertEquals(Curve.P_256, epk.getCurve());
+		assertNotNull(epk.getX());
+		assertNotNull(epk.getY());
+		assertNull(epk.getD());
+
+		assertNotNull(jweObject.getEncryptedKey());
+
+		String jwe = jweObject.serialize();
+
+		jweObject = JWEObject.parse(jwe);
+
+		ECDH1PUDecrypter decrypter = new ECDH1PUDecrypter(bobKey.toECPrivateKey(), aliceKey.toECPublicKey());
+		decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+		jweObject.decrypt(decrypter);
+
+		assertEquals("Hello world!", jweObject.getPayload().toString());
+	}
+
+	public void testCycle_ECDH_1PU_Curve_P384()
+		throws Exception {
+
+		ECKey aliceKey = generateECJWK(Curve.P_384);
+		ECKey bobKey = generateECJWK(Curve.P_384);
+
+		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128GCM).
+			agreementPartyUInfo(Base64URL.encode("Alice")).
+			agreementPartyVInfo(Base64URL.encode("Bob")).
+			build();
+
+		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+
+		ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey());
+		encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+		jweObject.encrypt(encrypter);
+
+		ECKey epk = (ECKey) jweObject.getHeader().getEphemeralPublicKey();
+		assertEquals(Curve.P_384, epk.getCurve());
+		assertNotNull(epk.getX());
+		assertNotNull(epk.getY());
+		assertNull(epk.getD());
+
+		assertNull(jweObject.getEncryptedKey());
+
+		String jwe = jweObject.serialize();
+
+		jweObject = JWEObject.parse(jwe);
+
+		ECDH1PUDecrypter decrypter = new ECDH1PUDecrypter(bobKey.toECPrivateKey(), aliceKey.toECPublicKey());
+		decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+		jweObject.decrypt(decrypter);
+
+		assertEquals("Hello world!", jweObject.getPayload().toString());
+	}
+
+
+	public void testCycle_ECDH_1PU_Curve_P384_A128KW()
+		throws Exception {
+
+		ECKey aliceKey = generateECJWK(Curve.P_384);
+		ECKey bobKey = generateECJWK(Curve.P_384);
+
+		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU_A128KW, EncryptionMethod.A256CBC_HS512).
+			agreementPartyUInfo(Base64URL.encode("Alice")).
+			agreementPartyVInfo(Base64URL.encode("Bob")).
+			build();
+
+		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+
+		ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey());
+		encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+		jweObject.encrypt(encrypter);
+
+		ECKey epk = (ECKey) jweObject.getHeader().getEphemeralPublicKey();
+		assertEquals(Curve.P_384, epk.getCurve());
+		assertNotNull(epk.getX());
+		assertNotNull(epk.getY());
+		assertNull(epk.getD());
+
+		assertNotNull(jweObject.getEncryptedKey());
+
+		String jwe = jweObject.serialize();
+
+		jweObject = JWEObject.parse(jwe);
+
+		ECDH1PUDecrypter decrypter = new ECDH1PUDecrypter(bobKey.toECPrivateKey(), aliceKey.toECPublicKey());
+		decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+		jweObject.decrypt(decrypter);
+
+		assertEquals("Hello world!", jweObject.getPayload().toString());
+	}
+
+
+	public void testCycle_ECDH_1PU_Curve_P521()
+		throws Exception {
+
+		ECKey aliceKey = generateECJWK(Curve.P_521);
+		ECKey bobKey = generateECJWK(Curve.P_521);
+
+		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128GCM).
+			agreementPartyUInfo(Base64URL.encode("Alice")).
+			agreementPartyVInfo(Base64URL.encode("Bob")).
+			build();
+
+		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+
+		ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey());
+		encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+		jweObject.encrypt(encrypter);
+
+		ECKey epk = (ECKey) jweObject.getHeader().getEphemeralPublicKey();
+		assertEquals(Curve.P_521, epk.getCurve());
+		assertNotNull(epk.getX());
+		assertNotNull(epk.getY());
+		assertNull(epk.getD());
+
+		assertNull(jweObject.getEncryptedKey());
+
+		String jwe = jweObject.serialize();
+
+		jweObject = JWEObject.parse(jwe);
+
+		ECDH1PUDecrypter decrypter = new ECDH1PUDecrypter(bobKey.toECPrivateKey(), aliceKey.toECPublicKey());
+		decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+		jweObject.decrypt(decrypter);
+
+		assertEquals("Hello world!", jweObject.getPayload().toString());
+	}
+
+
+	public void testCycle_ECDH_1PU_Curve_P521_A128KW()
+		throws Exception {
+
+		ECKey aliceKey = generateECJWK(Curve.P_521);
+		ECKey bobKey = generateECJWK(Curve.P_521);
+
+		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU_A128KW, EncryptionMethod.A256CBC_HS512).
+			agreementPartyUInfo(Base64URL.encode("Alice")).
+			agreementPartyVInfo(Base64URL.encode("Bob")).
+			build();
+
+		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+
+		ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey());
+		encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+		jweObject.encrypt(encrypter);
+
+		ECKey epk = (ECKey) jweObject.getHeader().getEphemeralPublicKey();
+		assertEquals(Curve.P_521, epk.getCurve());
+		assertNotNull(epk.getX());
+		assertNotNull(epk.getY());
+		assertNull(epk.getD());
+
+		assertNotNull(jweObject.getEncryptedKey());
+
+		String jwe = jweObject.serialize();
+
+		jweObject = JWEObject.parse(jwe);
+
+		ECDH1PUDecrypter decrypter = new ECDH1PUDecrypter(bobKey.toECPrivateKey(), aliceKey.toECPublicKey());
+		decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+		jweObject.decrypt(decrypter);
+
+		assertEquals("Hello world!", jweObject.getPayload().toString());
+	}
+
+	public void testCritParamDeferral()
+		throws Exception {
+
+		ECKey aliceKey = generateECJWK(Curve.P_256);
+		ECKey bobKey = generateECJWK(Curve.P_256);
+
+		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128CBC_HS256).
+			customParam("exp", "2014-04-24").
+			criticalParams(new HashSet<>(Collections.singletonList("exp"))).
+			build();
+
+		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+		jweObject.encrypt(new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey()));
+
+		jweObject = JWEObject.parse(jweObject.serialize());
+
+		jweObject.decrypt(new ECDH1PUDecrypter(
+				bobKey.toECPrivateKey(),
+				aliceKey.toECPublicKey(),
+				new HashSet<>(Collections.singletonList("exp"))));
+
+		assertEquals("Hello world!", jweObject.getPayload().toString());
+	}
+
+
+	public void testCritParamReject()
+		throws Exception {
+
+		ECKey aliceKey = generateECJWK(Curve.P_256);
+		ECKey bobKey = generateECJWK(Curve.P_256);
+
+		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128CBC_HS256).
+			customParam("exp", "2014-04-24").
+			criticalParams(new HashSet<>(Collections.singletonList("exp"))).
+			build();
+
+		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+		jweObject.encrypt(new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey()));
+
+		jweObject = JWEObject.parse(jweObject.serialize());
+
+		try {
+			jweObject.decrypt(new ECDH1PUDecrypter(bobKey.toECPrivateKey(), aliceKey.toECPublicKey()));
+			fail();
+		} catch (JOSEException e) {
+			// ok
+			assertEquals("Unsupported critical header parameter(s)", e.getMessage());
+		}
+	}
+}

--- a/src/test/java/com/nimbusds/jose/crypto/ECDH1PUCryptoTest.java
+++ b/src/test/java/com/nimbusds/jose/crypto/ECDH1PUCryptoTest.java
@@ -45,317 +45,317 @@ import java.util.HashSet;
  */
 public class ECDH1PUCryptoTest extends TestCase {
 
-	private static ECKey generateECJWK(final Curve curve)
-			throws Exception {
-
-		ECParameterSpec ecParameterSpec = curve.toECParameterSpec();
-
-		KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
-		generator.initialize(ecParameterSpec);
-		KeyPair keyPair = generator.generateKeyPair();
-
-		return new ECKey.Builder(curve, (ECPublicKey)keyPair.getPublic()).
-				privateKey((ECPrivateKey) keyPair.getPrivate()).
-				build();
-	}
-
-	private static class CycleTest {
-		public Curve curve;
-		public JWEAlgorithm algorithm;
-		public EncryptionMethod encryptionMethod;
-
-		public CycleTest(JWEAlgorithm algorithm, Curve curve, EncryptionMethod encryptionMethod) {
-			this.curve = curve;
-			this.algorithm = algorithm;
-			this.encryptionMethod = encryptionMethod;
-		}
-	}
-
-	private static final CycleTest[] allowedCycles = new CycleTest[] {
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_256, EncryptionMethod.A128CBC_HS256),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_256, EncryptionMethod.A192CBC_HS384),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_256, EncryptionMethod.A256CBC_HS512),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_256, EncryptionMethod.A128GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_256, EncryptionMethod.A192GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_256, EncryptionMethod.A256GCM),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_384, EncryptionMethod.A128CBC_HS256),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_384, EncryptionMethod.A192CBC_HS384),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_384, EncryptionMethod.A256CBC_HS512),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_384, EncryptionMethod.A128GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_384, EncryptionMethod.A192GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_384, EncryptionMethod.A256GCM),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_521, EncryptionMethod.A128CBC_HS256),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_521, EncryptionMethod.A192CBC_HS384),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_521, EncryptionMethod.A256CBC_HS512),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_521, EncryptionMethod.A128GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_521, EncryptionMethod.A192GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_521, EncryptionMethod.A256GCM),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_256, EncryptionMethod.A128CBC_HS256),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_256, EncryptionMethod.A192CBC_HS384),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_256, EncryptionMethod.A256CBC_HS512),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_384, EncryptionMethod.A128CBC_HS256),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_384, EncryptionMethod.A192CBC_HS384),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_384, EncryptionMethod.A256CBC_HS512),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_521, EncryptionMethod.A128CBC_HS256),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_521, EncryptionMethod.A192CBC_HS384),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_521, EncryptionMethod.A256CBC_HS512),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_256, EncryptionMethod.A128CBC_HS256),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_256, EncryptionMethod.A192CBC_HS384),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_256, EncryptionMethod.A256CBC_HS512),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_384, EncryptionMethod.A128CBC_HS256),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_384, EncryptionMethod.A192CBC_HS384),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_384, EncryptionMethod.A256CBC_HS512),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_521, EncryptionMethod.A128CBC_HS256),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_521, EncryptionMethod.A192CBC_HS384),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_521, EncryptionMethod.A256CBC_HS512),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_256, EncryptionMethod.A128CBC_HS256),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_256, EncryptionMethod.A192CBC_HS384),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_256, EncryptionMethod.A256CBC_HS512),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_384, EncryptionMethod.A128CBC_HS256),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_384, EncryptionMethod.A192CBC_HS384),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_384, EncryptionMethod.A256CBC_HS512),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_521, EncryptionMethod.A128CBC_HS256),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_521, EncryptionMethod.A192CBC_HS384),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_521, EncryptionMethod.A256CBC_HS512),
-	};
-
-	private static final CycleTest[] forbiddenCycles = new CycleTest[] {
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_256, EncryptionMethod.A128GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_256, EncryptionMethod.A192GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_256, EncryptionMethod.A256GCM),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_384, EncryptionMethod.A128GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_384, EncryptionMethod.A192GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_384, EncryptionMethod.A256GCM),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_521, EncryptionMethod.A128GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_521, EncryptionMethod.A192GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_521, EncryptionMethod.A256GCM),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_256, EncryptionMethod.A128GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_256, EncryptionMethod.A192GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_256, EncryptionMethod.A256GCM),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_384, EncryptionMethod.A128GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_384, EncryptionMethod.A192GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_384, EncryptionMethod.A256GCM),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_521, EncryptionMethod.A128GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_521, EncryptionMethod.A192GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_521, EncryptionMethod.A256GCM),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_256, EncryptionMethod.A128GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_256, EncryptionMethod.A192GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_256, EncryptionMethod.A256GCM),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_384, EncryptionMethod.A128GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_384, EncryptionMethod.A192GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_384, EncryptionMethod.A256GCM),
-
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_521, EncryptionMethod.A128GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_521, EncryptionMethod.A192GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_521, EncryptionMethod.A256GCM),
-	};
-
-	public void testCycle() throws Exception {
-		Payload payload = new Payload("Hello world!");
-
-		for (CycleTest cycle : allowedCycles) {
-			ECKey aliceKey = generateECJWK(cycle.curve);
-			ECKey bobKey = generateECJWK(cycle.curve);
-
-			JWEHeader header = new JWEHeader.Builder(cycle.algorithm, cycle.encryptionMethod).
-					agreementPartyUInfo(Base64URL.encode("Alice")).
-					agreementPartyVInfo(Base64URL.encode("Bob")).
-					build();
-
-			JWEObject jweObject = new JWEObject(header, payload);
-
-			ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey());
-			encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
-			jweObject.encrypt(encrypter);
+    private static ECKey generateECJWK(final Curve curve)
+            throws Exception {
+
+        ECParameterSpec ecParameterSpec = curve.toECParameterSpec();
+
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
+        generator.initialize(ecParameterSpec);
+        KeyPair keyPair = generator.generateKeyPair();
+
+        return new ECKey.Builder(curve, (ECPublicKey)keyPair.getPublic()).
+                privateKey((ECPrivateKey) keyPair.getPrivate()).
+                build();
+    }
+
+    private static class CycleTest {
+        public Curve curve;
+        public JWEAlgorithm algorithm;
+        public EncryptionMethod encryptionMethod;
+
+        public CycleTest(JWEAlgorithm algorithm, Curve curve, EncryptionMethod encryptionMethod) {
+            this.curve = curve;
+            this.algorithm = algorithm;
+            this.encryptionMethod = encryptionMethod;
+        }
+    }
+
+    private static final CycleTest[] allowedCycles = new CycleTest[] {
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_256, EncryptionMethod.A128CBC_HS256),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_256, EncryptionMethod.A192CBC_HS384),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_256, EncryptionMethod.A256CBC_HS512),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_256, EncryptionMethod.A128GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_256, EncryptionMethod.A192GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_256, EncryptionMethod.A256GCM),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_384, EncryptionMethod.A128CBC_HS256),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_384, EncryptionMethod.A192CBC_HS384),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_384, EncryptionMethod.A256CBC_HS512),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_384, EncryptionMethod.A128GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_384, EncryptionMethod.A192GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_384, EncryptionMethod.A256GCM),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_521, EncryptionMethod.A128CBC_HS256),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_521, EncryptionMethod.A192CBC_HS384),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_521, EncryptionMethod.A256CBC_HS512),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_521, EncryptionMethod.A128GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_521, EncryptionMethod.A192GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.P_521, EncryptionMethod.A256GCM),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_256, EncryptionMethod.A128CBC_HS256),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_256, EncryptionMethod.A192CBC_HS384),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_256, EncryptionMethod.A256CBC_HS512),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_384, EncryptionMethod.A128CBC_HS256),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_384, EncryptionMethod.A192CBC_HS384),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_384, EncryptionMethod.A256CBC_HS512),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_521, EncryptionMethod.A128CBC_HS256),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_521, EncryptionMethod.A192CBC_HS384),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_521, EncryptionMethod.A256CBC_HS512),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_256, EncryptionMethod.A128CBC_HS256),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_256, EncryptionMethod.A192CBC_HS384),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_256, EncryptionMethod.A256CBC_HS512),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_384, EncryptionMethod.A128CBC_HS256),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_384, EncryptionMethod.A192CBC_HS384),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_384, EncryptionMethod.A256CBC_HS512),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_521, EncryptionMethod.A128CBC_HS256),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_521, EncryptionMethod.A192CBC_HS384),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_521, EncryptionMethod.A256CBC_HS512),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_256, EncryptionMethod.A128CBC_HS256),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_256, EncryptionMethod.A192CBC_HS384),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_256, EncryptionMethod.A256CBC_HS512),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_384, EncryptionMethod.A128CBC_HS256),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_384, EncryptionMethod.A192CBC_HS384),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_384, EncryptionMethod.A256CBC_HS512),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_521, EncryptionMethod.A128CBC_HS256),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_521, EncryptionMethod.A192CBC_HS384),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_521, EncryptionMethod.A256CBC_HS512),
+    };
+
+    private static final CycleTest[] forbiddenCycles = new CycleTest[] {
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_256, EncryptionMethod.A128GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_256, EncryptionMethod.A192GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_256, EncryptionMethod.A256GCM),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_384, EncryptionMethod.A128GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_384, EncryptionMethod.A192GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_384, EncryptionMethod.A256GCM),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_521, EncryptionMethod.A128GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_521, EncryptionMethod.A192GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.P_521, EncryptionMethod.A256GCM),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_256, EncryptionMethod.A128GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_256, EncryptionMethod.A192GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_256, EncryptionMethod.A256GCM),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_384, EncryptionMethod.A128GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_384, EncryptionMethod.A192GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_384, EncryptionMethod.A256GCM),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_521, EncryptionMethod.A128GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_521, EncryptionMethod.A192GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.P_521, EncryptionMethod.A256GCM),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_256, EncryptionMethod.A128GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_256, EncryptionMethod.A192GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_256, EncryptionMethod.A256GCM),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_384, EncryptionMethod.A128GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_384, EncryptionMethod.A192GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_384, EncryptionMethod.A256GCM),
+
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_521, EncryptionMethod.A128GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_521, EncryptionMethod.A192GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.P_521, EncryptionMethod.A256GCM),
+    };
+
+    public void testCycle() throws Exception {
+        Payload payload = new Payload("Hello world!");
+
+        for (CycleTest cycle : allowedCycles) {
+            ECKey aliceKey = generateECJWK(cycle.curve);
+            ECKey bobKey = generateECJWK(cycle.curve);
+
+            JWEHeader header = new JWEHeader.Builder(cycle.algorithm, cycle.encryptionMethod).
+                    agreementPartyUInfo(Base64URL.encode("Alice")).
+                    agreementPartyVInfo(Base64URL.encode("Bob")).
+                    build();
+
+            JWEObject jweObject = new JWEObject(header, payload);
+
+            ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey());
+            encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+            jweObject.encrypt(encrypter);
 
-			ECKey epk = (ECKey) jweObject.getHeader().getEphemeralPublicKey();
-			assertEquals(cycle.curve, epk.getCurve());
-			assertNotNull(epk.getX());
-			assertNotNull(epk.getY());
-			assertNull(epk.getD());
-
-			String jwe = jweObject.serialize();
-			jweObject = JWEObject.parse(jwe);
-
-			ECDH1PUDecrypter decrypter = new ECDH1PUDecrypter(bobKey.toECPrivateKey(), aliceKey.toECPublicKey());
-			decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
-			jweObject.decrypt(decrypter);
+            ECKey epk = (ECKey) jweObject.getHeader().getEphemeralPublicKey();
+            assertEquals(cycle.curve, epk.getCurve());
+            assertNotNull(epk.getX());
+            assertNotNull(epk.getY());
+            assertNull(epk.getD());
+
+            String jwe = jweObject.serialize();
+            jweObject = JWEObject.parse(jwe);
+
+            ECDH1PUDecrypter decrypter = new ECDH1PUDecrypter(bobKey.toECPrivateKey(), aliceKey.toECPublicKey());
+            decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+            jweObject.decrypt(decrypter);
 
-			assertEquals(payload.toString(), jweObject.getPayload().toString());
-		}
-	}
+            assertEquals(payload.toString(), jweObject.getPayload().toString());
+        }
+    }
 
-	public void testCycle_isForbidden() throws Exception {
-		Payload payload = new Payload("Hello world!");
+    public void testCycle_isForbidden() throws Exception {
+        Payload payload = new Payload("Hello world!");
 
-		for (CycleTest cycle : forbiddenCycles) {
-			ECKey aliceKey = generateECJWK(cycle.curve);
-			ECKey bobKey = generateECJWK(cycle.curve);
+        for (CycleTest cycle : forbiddenCycles) {
+            ECKey aliceKey = generateECJWK(cycle.curve);
+            ECKey bobKey = generateECJWK(cycle.curve);
 
-			JWEHeader header = new JWEHeader.Builder(cycle.algorithm, cycle.encryptionMethod).
-					agreementPartyUInfo(Base64URL.encode("Alice")).
-					agreementPartyVInfo(Base64URL.encode("Bob")).
-					build();
+            JWEHeader header = new JWEHeader.Builder(cycle.algorithm, cycle.encryptionMethod).
+                    agreementPartyUInfo(Base64URL.encode("Alice")).
+                    agreementPartyVInfo(Base64URL.encode("Bob")).
+                    build();
 
-			JWEObject jweObject = new JWEObject(header, payload);
+            JWEObject jweObject = new JWEObject(header, payload);
 
-			try {
-				ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey());
-				encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
-				jweObject.encrypt(encrypter);
-				fail();
-			} catch (JOSEException e) {
-				String expectedMessage = String.format("Unsupported JWE encryption method %s, " +
-								"must be A128CBC-HS256, A192CBC-HS384 or A256CBC-HS512",
-						cycle.encryptionMethod.getName());
-				assertEquals(expectedMessage, e.getMessage());
-			}
-		}
-	}
-
-	public void testCycle_WithCekSpecified() throws Exception {
-		Payload payload = new Payload("Hello world!");
+            try {
+                ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey());
+                encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+                jweObject.encrypt(encrypter);
+                fail();
+            } catch (JOSEException e) {
+                String expectedMessage = String.format("Unsupported JWE encryption method %s, " +
+                                "must be A128CBC-HS256, A192CBC-HS384 or A256CBC-HS512",
+                        cycle.encryptionMethod.getName());
+                assertEquals(expectedMessage, e.getMessage());
+            }
+        }
+    }
+
+    public void testCycle_WithCekSpecified() throws Exception {
+        Payload payload = new Payload("Hello world!");
 
-		for (CycleTest cycle : allowedCycles) {
-			if (cycle.encryptionMethod.cekBitLength() == 0)
-				continue;
+        for (CycleTest cycle : allowedCycles) {
+            if (cycle.encryptionMethod.cekBitLength() == 0)
+                continue;
 
-			SecretKey cek = ContentCryptoProvider.generateCEK(cycle.encryptionMethod, new SecureRandom());
+            SecretKey cek = ContentCryptoProvider.generateCEK(cycle.encryptionMethod, new SecureRandom());
 
-			ECKey aliceKey = generateECJWK(cycle.curve);
-			ECKey bobKey = generateECJWK(cycle.curve);
+            ECKey aliceKey = generateECJWK(cycle.curve);
+            ECKey bobKey = generateECJWK(cycle.curve);
 
-			JWEHeader header = new JWEHeader.Builder(cycle.algorithm, cycle.encryptionMethod).
-					agreementPartyUInfo(Base64URL.encode("Alice")).
-					agreementPartyVInfo(Base64URL.encode("Bob")).
-					build();
+            JWEHeader header = new JWEHeader.Builder(cycle.algorithm, cycle.encryptionMethod).
+                    agreementPartyUInfo(Base64URL.encode("Alice")).
+                    agreementPartyVInfo(Base64URL.encode("Bob")).
+                    build();
 
-			JWEObject jweObject = new JWEObject(header, payload);
+            JWEObject jweObject = new JWEObject(header, payload);
 
-			ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey(), cek);
-			encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
-			jweObject.encrypt(encrypter);
+            ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey(), cek);
+            encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+            jweObject.encrypt(encrypter);
 
-			ECKey epk = (ECKey) jweObject.getHeader().getEphemeralPublicKey();
-			assertEquals(cycle.curve, epk.getCurve());
-			assertNotNull(epk.getX());
-			assertNotNull(epk.getY());
-			assertNull(epk.getD());
-
-			String jwe = jweObject.serialize();
-			jweObject = JWEObject.parse(jwe);
-
-			ECDH1PUDecrypter decrypter = new ECDH1PUDecrypter(bobKey.toECPrivateKey(), aliceKey.toECPublicKey());
-			decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
-			jweObject.decrypt(decrypter);
-
-			assertEquals(payload.toString(), jweObject.getPayload().toString());
-		}
-	}
-
-	public void testCritParamDeferral()
-		throws Exception {
-
-		ECKey aliceKey = generateECJWK(Curve.P_256);
-		ECKey bobKey = generateECJWK(Curve.P_256);
-
-		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128CBC_HS256).
-			customParam("exp", "2014-04-24").
-			criticalParams(new HashSet<>(Collections.singletonList("exp"))).
-			build();
-
-		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
-		jweObject.encrypt(new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey()));
-
-		jweObject = JWEObject.parse(jweObject.serialize());
-
-		jweObject.decrypt(new ECDH1PUDecrypter(
-				bobKey.toECPrivateKey(),
-				aliceKey.toECPublicKey(),
-				new HashSet<>(Collections.singletonList("exp"))));
-
-		assertEquals("Hello world!", jweObject.getPayload().toString());
-	}
-
-
-	public void testCritParamReject()
-		throws Exception {
-
-		ECKey aliceKey = generateECJWK(Curve.P_256);
-		ECKey bobKey = generateECJWK(Curve.P_256);
-
-		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128CBC_HS256).
-			customParam("exp", "2014-04-24").
-			criticalParams(new HashSet<>(Collections.singletonList("exp"))).
-			build();
-
-		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
-		jweObject.encrypt(new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey()));
-
-		jweObject = JWEObject.parse(jweObject.serialize());
-
-		try {
-			jweObject.decrypt(new ECDH1PUDecrypter(bobKey.toECPrivateKey(), aliceKey.toECPublicKey()));
-			fail();
-		} catch (JOSEException e) {
-			// ok
-			assertEquals("Unsupported critical header parameter(s)", e.getMessage());
-		}
-	}
-
-	public void testCurveNotMatch() throws Exception {
-		ECKey aliceKey = generateECJWK(Curve.P_256);
-		ECKey bobKey = generateECJWK(Curve.P_521);
-		ECKey correctBobKey = generateECJWK(Curve.P_256);
-
-		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU_A128KW, EncryptionMethod.A256CBC_HS512).
-				agreementPartyUInfo(Base64URL.encode("Alice")).
-				agreementPartyVInfo(Base64URL.encode("Bob")).
-				build();
-
-		JWEObject jweObject = new JWEObject(header, new Payload("Hello, world"));
-
-		try {
-
-			ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey());
-			encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
-			jweObject.encrypt(encrypter);
-
-			fail();
-		} catch (JOSEException e) {
-			assertEquals("Curve of public key does not match curve of private key", e.getMessage());
-		}
-
-		try {
-			ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), correctBobKey.toECPublicKey());
-			encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
-			jweObject.encrypt(encrypter);
-
-			ECDH1PUDecrypter decrypter = new ECDH1PUDecrypter(bobKey.toECPrivateKey(), aliceKey.toECPublicKey());
-			decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
-			jweObject.decrypt(decrypter);
-
-			fail();
-		} catch (JOSEException e) {
-			assertEquals("Curve of public key does not match curve of private key", e.getMessage());
-		}
-	}
+            ECKey epk = (ECKey) jweObject.getHeader().getEphemeralPublicKey();
+            assertEquals(cycle.curve, epk.getCurve());
+            assertNotNull(epk.getX());
+            assertNotNull(epk.getY());
+            assertNull(epk.getD());
+
+            String jwe = jweObject.serialize();
+            jweObject = JWEObject.parse(jwe);
+
+            ECDH1PUDecrypter decrypter = new ECDH1PUDecrypter(bobKey.toECPrivateKey(), aliceKey.toECPublicKey());
+            decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+            jweObject.decrypt(decrypter);
+
+            assertEquals(payload.toString(), jweObject.getPayload().toString());
+        }
+    }
+
+    public void testCritParamDeferral()
+        throws Exception {
+
+        ECKey aliceKey = generateECJWK(Curve.P_256);
+        ECKey bobKey = generateECJWK(Curve.P_256);
+
+        JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128CBC_HS256).
+            customParam("exp", "2014-04-24").
+            criticalParams(new HashSet<>(Collections.singletonList("exp"))).
+            build();
+
+        JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+        jweObject.encrypt(new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey()));
+
+        jweObject = JWEObject.parse(jweObject.serialize());
+
+        jweObject.decrypt(new ECDH1PUDecrypter(
+                bobKey.toECPrivateKey(),
+                aliceKey.toECPublicKey(),
+                new HashSet<>(Collections.singletonList("exp"))));
+
+        assertEquals("Hello world!", jweObject.getPayload().toString());
+    }
+
+
+    public void testCritParamReject()
+        throws Exception {
+
+        ECKey aliceKey = generateECJWK(Curve.P_256);
+        ECKey bobKey = generateECJWK(Curve.P_256);
+
+        JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128CBC_HS256).
+            customParam("exp", "2014-04-24").
+            criticalParams(new HashSet<>(Collections.singletonList("exp"))).
+            build();
+
+        JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+        jweObject.encrypt(new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey()));
+
+        jweObject = JWEObject.parse(jweObject.serialize());
+
+        try {
+            jweObject.decrypt(new ECDH1PUDecrypter(bobKey.toECPrivateKey(), aliceKey.toECPublicKey()));
+            fail();
+        } catch (JOSEException e) {
+            // ok
+            assertEquals("Unsupported critical header parameter(s)", e.getMessage());
+        }
+    }
+
+    public void testCurveNotMatch() throws Exception {
+        ECKey aliceKey = generateECJWK(Curve.P_256);
+        ECKey bobKey = generateECJWK(Curve.P_521);
+        ECKey correctBobKey = generateECJWK(Curve.P_256);
+
+        JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU_A128KW, EncryptionMethod.A256CBC_HS512).
+                agreementPartyUInfo(Base64URL.encode("Alice")).
+                agreementPartyVInfo(Base64URL.encode("Bob")).
+                build();
+
+        JWEObject jweObject = new JWEObject(header, new Payload("Hello, world"));
+
+        try {
+
+            ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), bobKey.toECPublicKey());
+            encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+            jweObject.encrypt(encrypter);
+
+            fail();
+        } catch (JOSEException e) {
+            assertEquals("Curve of public key does not match curve of private key", e.getMessage());
+        }
+
+        try {
+            ECDH1PUEncrypter encrypter = new ECDH1PUEncrypter(aliceKey.toECPrivateKey(), correctBobKey.toECPublicKey());
+            encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+            jweObject.encrypt(encrypter);
+
+            ECDH1PUDecrypter decrypter = new ECDH1PUDecrypter(bobKey.toECPrivateKey(), aliceKey.toECPublicKey());
+            decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+            jweObject.decrypt(decrypter);
+
+            fail();
+        } catch (JOSEException e) {
+            assertEquals("Curve of public key does not match curve of private key", e.getMessage());
+        }
+    }
 }

--- a/src/test/java/com/nimbusds/jose/crypto/ECDH1PUTest.java
+++ b/src/test/java/com/nimbusds/jose/crypto/ECDH1PUTest.java
@@ -1,0 +1,249 @@
+/*
+ * nimbus-jose-jwt
+ *
+ * Copyright 2012-2021, Connect2id Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.nimbusds.jose.crypto;
+
+
+import com.google.crypto.tink.subtle.X25519;
+import com.nimbusds.jose.EncryptionMethod;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEAlgorithm;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.crypto.impl.AESKW;
+import com.nimbusds.jose.crypto.impl.ConcatKDF;
+import com.nimbusds.jose.crypto.impl.ECDH1PU;
+import com.nimbusds.jose.jca.JWEJCAContext;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.OctetKeyPair;
+import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator;
+import com.nimbusds.jose.util.Base64URL;
+import junit.framework.TestCase;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Tests the ECDH-1PU key agreement derivation.
+ *
+ * @version 2021-08-05
+ * @author Alexander Martynov
+ */
+public class ECDH1PUTest extends TestCase{
+
+	private static ECKey generateECJWK(final Curve curve)
+			throws Exception {
+
+		ECParameterSpec ecParameterSpec = curve.toECParameterSpec();
+
+		KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
+		generator.initialize(ecParameterSpec);
+		KeyPair keyPair = generator.generateKeyPair();
+
+		return new ECKey.Builder(curve, (ECPublicKey)keyPair.getPublic()).
+				privateKey((ECPrivateKey) keyPair.getPrivate()).
+				build();
+	}
+
+	private static OctetKeyPair generateOKP(Curve curve)
+			throws Exception {
+
+		return new OctetKeyPairGenerator(curve).generate();
+	}
+
+	private static class TestVector {
+		public JWEAlgorithm algorithm;
+		public EncryptionMethod encryptionMethod;
+		public byte[] Ze;
+		public byte[] Zs;
+		public byte[] expectedZ;
+		public byte[] expectedSharedKey;
+		public Base64URL tag = null;
+		public String apu;
+		public String apv;
+
+		public TestVector(
+				JWEAlgorithm algorithm,
+				EncryptionMethod encryptionMethod,
+				byte[] Ze,
+				byte[] Zs,
+				byte[] expectedZ,
+				byte[] expectedSharedKey,
+				Base64URL tag,
+				String apu,
+				String apv) {
+			this.algorithm = algorithm;
+			this.encryptionMethod = encryptionMethod;
+			this.Ze = Ze;
+			this.Zs = Zs;
+			this.expectedZ = expectedZ;
+			this.expectedSharedKey = expectedSharedKey;
+			this.tag = tag;
+			this.apu = apu;
+			this.apv = apv;
+		}
+	}
+
+	private static final TestVector[] testVectors = new TestVector[] {
+			// https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#appendix-A
+			new TestVector(
+					JWEAlgorithm.ECDH_1PU,
+					EncryptionMethod.A256GCM,
+					fromHex("9e56d91d817135d372834283bf84269cfb316ea3da806a48f6daa7798cfe90c4"),
+					fromHex("e3ca3474384c9f62b30bfd4c688b3e7d4110a1b4badc3cc54ef7b81241efd50d"),
+					fromHex("9e56d91d817135d372834283bf84269cfb316ea3da806a48f6daa7798cfe90c4" +
+									"e3ca3474384c9f62b30bfd4c688b3e7d4110a1b4badc3cc54ef7b81241efd50d"),
+					fromHex("6caf13723d14850ad4b42cd6dde935bffd2fff00a9ba70de05c203a5e1722ca7"),
+					null,
+					"Alice",
+					"Bob"
+			),
+
+			// https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#appendix-B.9
+			new TestVector(
+					JWEAlgorithm.ECDH_1PU_A128KW,
+					EncryptionMethod.A256CBC_HS512,
+					fromHex("32810896e0fe4d570ed1acfcedf67117dc194ed5daac21d8ff7af3244694897f"),
+					fromHex("2157612c9048edfae77cb2e4237140605967c05c7f77a48eeaf2cf29a5737c4a"),
+					fromHex("32810896e0fe4d570ed1acfcedf67117dc194ed5daac21d8ff7af3244694897f" +
+									"2157612c9048edfae77cb2e4237140605967c05c7f77a48eeaf2cf29a5737c4a"),
+					fromHex("df4c37a0668306a11e3d6b0074b5d8df"),
+					Base64URL.from("HLb4fTlm8spGmij3RyOs2gJ4DpHM4hhVRwdF_hGb3WQ"),
+					"Alice",
+					"Bob and Charlie"
+			),
+
+			// https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#appendix-B.10
+			new TestVector(
+					JWEAlgorithm.ECDH_1PU_A128KW,
+					EncryptionMethod.A256CBC_HS512,
+					fromHex("89dcfe4c37c1dc0271f346b5b3b19c3b705ca2a72f9a237785c34406fcb75f10"),
+					fromHex("78fe63fc661cf8d18f92a8422a6418e4ed5e20a9168185fdeedca1c3d8e6a61c"),
+					fromHex("89dcfe4c37c1dc0271f346b5b3b19c3b705ca2a72f9a237785c34406fcb75f10" +
+							"78fe63fc661cf8d18f92a8422a6418e4ed5e20a9168185fdeedca1c3d8e6a61c"),
+					fromHex("57d8126f1b7ec4ccb0584dac03cb27cc"),
+					Base64URL.from("HLb4fTlm8spGmij3RyOs2gJ4DpHM4hhVRwdF_hGb3WQ"),
+					"Alice",
+					"Bob and Charlie"
+			)
+	};
+
+	private static byte[] fromHex(String hex) {
+		byte[] result = new byte[hex.length() / 2];
+		for (int i=0; i<result.length; i++) {
+			result[i] = (byte) Integer.parseInt(hex.substring(2*i, 2*i + 2), 16);
+		}
+		return result;
+	}
+
+	public void testSameCurve() throws Exception {
+		ECPrivateKey aliceKeyP_256 = generateECJWK(Curve.P_256).toECPrivateKey();
+		ECPublicKey bobKeyP_256 = generateECJWK(Curve.P_256).toECPublicKey();
+		ECDH1PU.validateSameCurve(aliceKeyP_256, bobKeyP_256);
+
+		ECPrivateKey aliceKeyP_384 = generateECJWK(Curve.P_384).toECPrivateKey();
+		ECPublicKey bobKeyP_384 = generateECJWK(Curve.P_384).toECPublicKey();
+		ECDH1PU.validateSameCurve(aliceKeyP_384, bobKeyP_384);
+
+		ECPrivateKey aliceKeyP_521 = generateECJWK(Curve.P_521).toECPrivateKey();
+		ECPublicKey bobKeyP_521 = generateECJWK(Curve.P_521).toECPublicKey();
+		ECDH1PU.validateSameCurve(aliceKeyP_521, bobKeyP_521);
+
+		OctetKeyPair aliceOKPKey = generateOKP(Curve.X25519);
+		OctetKeyPair bobOKPKey = generateOKP(Curve.X25519).toPublicJWK();
+		ECDH1PU.validateSameCurve(aliceOKPKey, bobOKPKey);
+	}
+
+	public void testCurveNotMatch() throws Exception {
+		try {
+			ECPrivateKey aliceKeyP_256 = generateECJWK(Curve.P_256).toECPrivateKey();
+			ECPublicKey bobKeyP_521 = generateECJWK(Curve.P_521).toECPublicKey();
+			ECDH1PU.validateSameCurve(aliceKeyP_256, bobKeyP_521);
+			fail();
+		} catch (JOSEException e) {
+			assertEquals("Curve of public key does not match curve of private key", e.getMessage());
+		}
+
+		try {
+			OctetKeyPair aliceOKPKey = generateOKP(Curve.X25519);
+			OctetKeyPair bobOKPKey = generateOKP(Curve.X25519);
+			ECDH1PU.validateSameCurve(aliceOKPKey, bobOKPKey);
+			fail();
+		} catch (JOSEException e) {
+			assertEquals("OKP public key should not be a private key", e.getMessage());
+		}
+
+		try {
+			OctetKeyPair aliceOKPKey = generateOKP(Curve.X25519).toPublicJWK();
+			OctetKeyPair bobOKPKey = generateOKP(Curve.X25519);
+			ECDH1PU.validateSameCurve(aliceOKPKey, bobOKPKey);
+			fail();
+		} catch (JOSEException e) {
+			assertEquals("OKP private key should be a private key", e.getMessage());
+		}
+
+		try {
+			OctetKeyPair aliceOKPKey = generateOKP(Curve.Ed25519);
+			OctetKeyPair bobOKPKey = generateOKP(Curve.X25519).toPublicJWK();
+			ECDH1PU.validateSameCurve(aliceOKPKey, bobOKPKey);
+			fail();
+		} catch (JOSEException e) {
+			assertEquals("Curve of public key does not match curve of private key", e.getMessage());
+		}
+
+		try {
+			OctetKeyPair aliceOKPKey = generateOKP(Curve.Ed25519);
+			OctetKeyPair bobOKPKey = generateOKP(Curve.Ed25519).toPublicJWK();
+			ECDH1PU.validateSameCurve(aliceOKPKey, bobOKPKey);
+			fail();
+		} catch (JOSEException e) {
+			assertEquals("Only supports OctetKeyPairs with crv=X25519", e.getMessage());
+		}
+	}
+
+	public void test_TestVectors() throws Exception {
+		for (TestVector vector : testVectors) {
+			SecretKey Ze = new SecretKeySpec(vector.Ze, "AES");
+			SecretKey Zs = new SecretKeySpec(vector.Zs, "AES");
+			SecretKey Z = ECDH1PU.deriveZ(Ze, Zs);
+
+			assertArrayEquals(vector.expectedZ, Z.getEncoded());
+
+			JWEHeader jwe = new JWEHeader.Builder(vector.algorithm, vector.encryptionMethod)
+					.agreementPartyUInfo(Base64URL.encode(vector.apu))
+					.agreementPartyVInfo(Base64URL.encode(vector.apv))
+					.build();
+
+			if (vector.tag == null) {
+				SecretKey sharedKey = ECDH1PU.deriveSharedKey(jwe, Z, new ConcatKDF("SHA-256"));
+				assertArrayEquals(vector.expectedSharedKey, sharedKey.getEncoded());
+			}
+
+			if (vector.tag != null) {
+				SecretKey sharedKey = ECDH1PU.deriveSharedKey(jwe, Z, vector.tag, new ConcatKDF("SHA-256"));
+				assertArrayEquals(vector.expectedSharedKey, sharedKey.getEncoded());
+			}
+		}
+	}
+}

--- a/src/test/java/com/nimbusds/jose/crypto/ECDH1PUTest.java
+++ b/src/test/java/com/nimbusds/jose/crypto/ECDH1PUTest.java
@@ -1,7 +1,7 @@
 /*
  * nimbus-jose-jwt
  *
- * Copyright 2012-2021, Connect2id Ltd.
+ * Copyright 2012-2021, Connect2id Ltd and contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy of the
@@ -18,15 +18,12 @@
 package com.nimbusds.jose.crypto;
 
 
-import com.google.crypto.tink.subtle.X25519;
 import com.nimbusds.jose.EncryptionMethod;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWEAlgorithm;
 import com.nimbusds.jose.JWEHeader;
-import com.nimbusds.jose.crypto.impl.AESKW;
 import com.nimbusds.jose.crypto.impl.ConcatKDF;
 import com.nimbusds.jose.crypto.impl.ECDH1PU;
-import com.nimbusds.jose.jca.JWEJCAContext;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.OctetKeyPair;
@@ -79,7 +76,7 @@ public class ECDH1PUTest extends TestCase{
 		public byte[] Zs;
 		public byte[] expectedZ;
 		public byte[] expectedSharedKey;
-		public Base64URL tag = null;
+		public Base64URL tag;
 		public String apu;
 		public String apv;
 

--- a/src/test/java/com/nimbusds/jose/crypto/ECDH1PUTest.java
+++ b/src/test/java/com/nimbusds/jose/crypto/ECDH1PUTest.java
@@ -49,198 +49,198 @@ import static org.junit.Assert.assertArrayEquals;
  */
 public class ECDH1PUTest extends TestCase{
 
-	private static ECKey generateECJWK(final Curve curve)
-			throws Exception {
+    private static ECKey generateECJWK(final Curve curve)
+            throws Exception {
 
-		ECParameterSpec ecParameterSpec = curve.toECParameterSpec();
+        ECParameterSpec ecParameterSpec = curve.toECParameterSpec();
 
-		KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
-		generator.initialize(ecParameterSpec);
-		KeyPair keyPair = generator.generateKeyPair();
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
+        generator.initialize(ecParameterSpec);
+        KeyPair keyPair = generator.generateKeyPair();
 
-		return new ECKey.Builder(curve, (ECPublicKey)keyPair.getPublic()).
-				privateKey((ECPrivateKey) keyPair.getPrivate()).
-				build();
-	}
+        return new ECKey.Builder(curve, (ECPublicKey)keyPair.getPublic()).
+                privateKey((ECPrivateKey) keyPair.getPrivate()).
+                build();
+    }
 
-	private static OctetKeyPair generateOKP(Curve curve)
-			throws Exception {
+    private static OctetKeyPair generateOKP(Curve curve)
+            throws Exception {
 
-		return new OctetKeyPairGenerator(curve).generate();
-	}
+        return new OctetKeyPairGenerator(curve).generate();
+    }
 
-	private static class TestVector {
-		public JWEAlgorithm algorithm;
-		public EncryptionMethod encryptionMethod;
-		public byte[] Ze;
-		public byte[] Zs;
-		public byte[] expectedZ;
-		public byte[] expectedSharedKey;
-		public Base64URL tag;
-		public String apu;
-		public String apv;
+    private static class TestVector {
+        public JWEAlgorithm algorithm;
+        public EncryptionMethod encryptionMethod;
+        public byte[] Ze;
+        public byte[] Zs;
+        public byte[] expectedZ;
+        public byte[] expectedSharedKey;
+        public Base64URL tag;
+        public String apu;
+        public String apv;
 
-		public TestVector(
-				JWEAlgorithm algorithm,
-				EncryptionMethod encryptionMethod,
-				byte[] Ze,
-				byte[] Zs,
-				byte[] expectedZ,
-				byte[] expectedSharedKey,
-				Base64URL tag,
-				String apu,
-				String apv) {
-			this.algorithm = algorithm;
-			this.encryptionMethod = encryptionMethod;
-			this.Ze = Ze;
-			this.Zs = Zs;
-			this.expectedZ = expectedZ;
-			this.expectedSharedKey = expectedSharedKey;
-			this.tag = tag;
-			this.apu = apu;
-			this.apv = apv;
-		}
-	}
+        public TestVector(
+                JWEAlgorithm algorithm,
+                EncryptionMethod encryptionMethod,
+                byte[] Ze,
+                byte[] Zs,
+                byte[] expectedZ,
+                byte[] expectedSharedKey,
+                Base64URL tag,
+                String apu,
+                String apv) {
+            this.algorithm = algorithm;
+            this.encryptionMethod = encryptionMethod;
+            this.Ze = Ze;
+            this.Zs = Zs;
+            this.expectedZ = expectedZ;
+            this.expectedSharedKey = expectedSharedKey;
+            this.tag = tag;
+            this.apu = apu;
+            this.apv = apv;
+        }
+    }
 
-	private static final TestVector[] testVectors = new TestVector[] {
-			// https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#appendix-A
-			new TestVector(
-					JWEAlgorithm.ECDH_1PU,
-					EncryptionMethod.A256GCM,
-					fromHex("9e56d91d817135d372834283bf84269cfb316ea3da806a48f6daa7798cfe90c4"),
-					fromHex("e3ca3474384c9f62b30bfd4c688b3e7d4110a1b4badc3cc54ef7b81241efd50d"),
-					fromHex("9e56d91d817135d372834283bf84269cfb316ea3da806a48f6daa7798cfe90c4" +
-									"e3ca3474384c9f62b30bfd4c688b3e7d4110a1b4badc3cc54ef7b81241efd50d"),
-					fromHex("6caf13723d14850ad4b42cd6dde935bffd2fff00a9ba70de05c203a5e1722ca7"),
-					null,
-					"Alice",
-					"Bob"
-			),
+    private static final TestVector[] testVectors = new TestVector[] {
+            // https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#appendix-A
+            new TestVector(
+                    JWEAlgorithm.ECDH_1PU,
+                    EncryptionMethod.A256GCM,
+                    fromHex("9e56d91d817135d372834283bf84269cfb316ea3da806a48f6daa7798cfe90c4"),
+                    fromHex("e3ca3474384c9f62b30bfd4c688b3e7d4110a1b4badc3cc54ef7b81241efd50d"),
+                    fromHex("9e56d91d817135d372834283bf84269cfb316ea3da806a48f6daa7798cfe90c4" +
+                                    "e3ca3474384c9f62b30bfd4c688b3e7d4110a1b4badc3cc54ef7b81241efd50d"),
+                    fromHex("6caf13723d14850ad4b42cd6dde935bffd2fff00a9ba70de05c203a5e1722ca7"),
+                    null,
+                    "Alice",
+                    "Bob"
+            ),
 
-			// https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#appendix-B.9
-			new TestVector(
-					JWEAlgorithm.ECDH_1PU_A128KW,
-					EncryptionMethod.A256CBC_HS512,
-					fromHex("32810896e0fe4d570ed1acfcedf67117dc194ed5daac21d8ff7af3244694897f"),
-					fromHex("2157612c9048edfae77cb2e4237140605967c05c7f77a48eeaf2cf29a5737c4a"),
-					fromHex("32810896e0fe4d570ed1acfcedf67117dc194ed5daac21d8ff7af3244694897f" +
-									"2157612c9048edfae77cb2e4237140605967c05c7f77a48eeaf2cf29a5737c4a"),
-					fromHex("df4c37a0668306a11e3d6b0074b5d8df"),
-					Base64URL.from("HLb4fTlm8spGmij3RyOs2gJ4DpHM4hhVRwdF_hGb3WQ"),
-					"Alice",
-					"Bob and Charlie"
-			),
+            // https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#appendix-B.9
+            new TestVector(
+                    JWEAlgorithm.ECDH_1PU_A128KW,
+                    EncryptionMethod.A256CBC_HS512,
+                    fromHex("32810896e0fe4d570ed1acfcedf67117dc194ed5daac21d8ff7af3244694897f"),
+                    fromHex("2157612c9048edfae77cb2e4237140605967c05c7f77a48eeaf2cf29a5737c4a"),
+                    fromHex("32810896e0fe4d570ed1acfcedf67117dc194ed5daac21d8ff7af3244694897f" +
+                                    "2157612c9048edfae77cb2e4237140605967c05c7f77a48eeaf2cf29a5737c4a"),
+                    fromHex("df4c37a0668306a11e3d6b0074b5d8df"),
+                    Base64URL.from("HLb4fTlm8spGmij3RyOs2gJ4DpHM4hhVRwdF_hGb3WQ"),
+                    "Alice",
+                    "Bob and Charlie"
+            ),
 
-			// https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#appendix-B.10
-			new TestVector(
-					JWEAlgorithm.ECDH_1PU_A128KW,
-					EncryptionMethod.A256CBC_HS512,
-					fromHex("89dcfe4c37c1dc0271f346b5b3b19c3b705ca2a72f9a237785c34406fcb75f10"),
-					fromHex("78fe63fc661cf8d18f92a8422a6418e4ed5e20a9168185fdeedca1c3d8e6a61c"),
-					fromHex("89dcfe4c37c1dc0271f346b5b3b19c3b705ca2a72f9a237785c34406fcb75f10" +
-							"78fe63fc661cf8d18f92a8422a6418e4ed5e20a9168185fdeedca1c3d8e6a61c"),
-					fromHex("57d8126f1b7ec4ccb0584dac03cb27cc"),
-					Base64URL.from("HLb4fTlm8spGmij3RyOs2gJ4DpHM4hhVRwdF_hGb3WQ"),
-					"Alice",
-					"Bob and Charlie"
-			)
-	};
+            // https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#appendix-B.10
+            new TestVector(
+                    JWEAlgorithm.ECDH_1PU_A128KW,
+                    EncryptionMethod.A256CBC_HS512,
+                    fromHex("89dcfe4c37c1dc0271f346b5b3b19c3b705ca2a72f9a237785c34406fcb75f10"),
+                    fromHex("78fe63fc661cf8d18f92a8422a6418e4ed5e20a9168185fdeedca1c3d8e6a61c"),
+                    fromHex("89dcfe4c37c1dc0271f346b5b3b19c3b705ca2a72f9a237785c34406fcb75f10" +
+                            "78fe63fc661cf8d18f92a8422a6418e4ed5e20a9168185fdeedca1c3d8e6a61c"),
+                    fromHex("57d8126f1b7ec4ccb0584dac03cb27cc"),
+                    Base64URL.from("HLb4fTlm8spGmij3RyOs2gJ4DpHM4hhVRwdF_hGb3WQ"),
+                    "Alice",
+                    "Bob and Charlie"
+            )
+    };
 
-	private static byte[] fromHex(String hex) {
-		byte[] result = new byte[hex.length() / 2];
-		for (int i=0; i<result.length; i++) {
-			result[i] = (byte) Integer.parseInt(hex.substring(2*i, 2*i + 2), 16);
-		}
-		return result;
-	}
+    private static byte[] fromHex(String hex) {
+        byte[] result = new byte[hex.length() / 2];
+        for (int i=0; i<result.length; i++) {
+            result[i] = (byte) Integer.parseInt(hex.substring(2*i, 2*i + 2), 16);
+        }
+        return result;
+    }
 
-	public void testSameCurve() throws Exception {
-		ECPrivateKey aliceKeyP_256 = generateECJWK(Curve.P_256).toECPrivateKey();
-		ECPublicKey bobKeyP_256 = generateECJWK(Curve.P_256).toECPublicKey();
-		ECDH1PU.validateSameCurve(aliceKeyP_256, bobKeyP_256);
+    public void testSameCurve() throws Exception {
+        ECPrivateKey aliceKeyP_256 = generateECJWK(Curve.P_256).toECPrivateKey();
+        ECPublicKey bobKeyP_256 = generateECJWK(Curve.P_256).toECPublicKey();
+        ECDH1PU.validateSameCurve(aliceKeyP_256, bobKeyP_256);
 
-		ECPrivateKey aliceKeyP_384 = generateECJWK(Curve.P_384).toECPrivateKey();
-		ECPublicKey bobKeyP_384 = generateECJWK(Curve.P_384).toECPublicKey();
-		ECDH1PU.validateSameCurve(aliceKeyP_384, bobKeyP_384);
+        ECPrivateKey aliceKeyP_384 = generateECJWK(Curve.P_384).toECPrivateKey();
+        ECPublicKey bobKeyP_384 = generateECJWK(Curve.P_384).toECPublicKey();
+        ECDH1PU.validateSameCurve(aliceKeyP_384, bobKeyP_384);
 
-		ECPrivateKey aliceKeyP_521 = generateECJWK(Curve.P_521).toECPrivateKey();
-		ECPublicKey bobKeyP_521 = generateECJWK(Curve.P_521).toECPublicKey();
-		ECDH1PU.validateSameCurve(aliceKeyP_521, bobKeyP_521);
+        ECPrivateKey aliceKeyP_521 = generateECJWK(Curve.P_521).toECPrivateKey();
+        ECPublicKey bobKeyP_521 = generateECJWK(Curve.P_521).toECPublicKey();
+        ECDH1PU.validateSameCurve(aliceKeyP_521, bobKeyP_521);
 
-		OctetKeyPair aliceOKPKey = generateOKP(Curve.X25519);
-		OctetKeyPair bobOKPKey = generateOKP(Curve.X25519).toPublicJWK();
-		ECDH1PU.validateSameCurve(aliceOKPKey, bobOKPKey);
-	}
+        OctetKeyPair aliceOKPKey = generateOKP(Curve.X25519);
+        OctetKeyPair bobOKPKey = generateOKP(Curve.X25519).toPublicJWK();
+        ECDH1PU.validateSameCurve(aliceOKPKey, bobOKPKey);
+    }
 
-	public void testCurveNotMatch() throws Exception {
-		try {
-			ECPrivateKey aliceKeyP_256 = generateECJWK(Curve.P_256).toECPrivateKey();
-			ECPublicKey bobKeyP_521 = generateECJWK(Curve.P_521).toECPublicKey();
-			ECDH1PU.validateSameCurve(aliceKeyP_256, bobKeyP_521);
-			fail();
-		} catch (JOSEException e) {
-			assertEquals("Curve of public key does not match curve of private key", e.getMessage());
-		}
+    public void testCurveNotMatch() throws Exception {
+        try {
+            ECPrivateKey aliceKeyP_256 = generateECJWK(Curve.P_256).toECPrivateKey();
+            ECPublicKey bobKeyP_521 = generateECJWK(Curve.P_521).toECPublicKey();
+            ECDH1PU.validateSameCurve(aliceKeyP_256, bobKeyP_521);
+            fail();
+        } catch (JOSEException e) {
+            assertEquals("Curve of public key does not match curve of private key", e.getMessage());
+        }
 
-		try {
-			OctetKeyPair aliceOKPKey = generateOKP(Curve.X25519);
-			OctetKeyPair bobOKPKey = generateOKP(Curve.X25519);
-			ECDH1PU.validateSameCurve(aliceOKPKey, bobOKPKey);
-			fail();
-		} catch (JOSEException e) {
-			assertEquals("OKP public key should not be a private key", e.getMessage());
-		}
+        try {
+            OctetKeyPair aliceOKPKey = generateOKP(Curve.X25519);
+            OctetKeyPair bobOKPKey = generateOKP(Curve.X25519);
+            ECDH1PU.validateSameCurve(aliceOKPKey, bobOKPKey);
+            fail();
+        } catch (JOSEException e) {
+            assertEquals("OKP public key should not be a private key", e.getMessage());
+        }
 
-		try {
-			OctetKeyPair aliceOKPKey = generateOKP(Curve.X25519).toPublicJWK();
-			OctetKeyPair bobOKPKey = generateOKP(Curve.X25519);
-			ECDH1PU.validateSameCurve(aliceOKPKey, bobOKPKey);
-			fail();
-		} catch (JOSEException e) {
-			assertEquals("OKP private key should be a private key", e.getMessage());
-		}
+        try {
+            OctetKeyPair aliceOKPKey = generateOKP(Curve.X25519).toPublicJWK();
+            OctetKeyPair bobOKPKey = generateOKP(Curve.X25519);
+            ECDH1PU.validateSameCurve(aliceOKPKey, bobOKPKey);
+            fail();
+        } catch (JOSEException e) {
+            assertEquals("OKP private key should be a private key", e.getMessage());
+        }
 
-		try {
-			OctetKeyPair aliceOKPKey = generateOKP(Curve.Ed25519);
-			OctetKeyPair bobOKPKey = generateOKP(Curve.X25519).toPublicJWK();
-			ECDH1PU.validateSameCurve(aliceOKPKey, bobOKPKey);
-			fail();
-		} catch (JOSEException e) {
-			assertEquals("Curve of public key does not match curve of private key", e.getMessage());
-		}
+        try {
+            OctetKeyPair aliceOKPKey = generateOKP(Curve.Ed25519);
+            OctetKeyPair bobOKPKey = generateOKP(Curve.X25519).toPublicJWK();
+            ECDH1PU.validateSameCurve(aliceOKPKey, bobOKPKey);
+            fail();
+        } catch (JOSEException e) {
+            assertEquals("Curve of public key does not match curve of private key", e.getMessage());
+        }
 
-		try {
-			OctetKeyPair aliceOKPKey = generateOKP(Curve.Ed25519);
-			OctetKeyPair bobOKPKey = generateOKP(Curve.Ed25519).toPublicJWK();
-			ECDH1PU.validateSameCurve(aliceOKPKey, bobOKPKey);
-			fail();
-		} catch (JOSEException e) {
-			assertEquals("Only supports OctetKeyPairs with crv=X25519", e.getMessage());
-		}
-	}
+        try {
+            OctetKeyPair aliceOKPKey = generateOKP(Curve.Ed25519);
+            OctetKeyPair bobOKPKey = generateOKP(Curve.Ed25519).toPublicJWK();
+            ECDH1PU.validateSameCurve(aliceOKPKey, bobOKPKey);
+            fail();
+        } catch (JOSEException e) {
+            assertEquals("Only supports OctetKeyPairs with crv=X25519", e.getMessage());
+        }
+    }
 
-	public void test_TestVectors() throws Exception {
-		for (TestVector vector : testVectors) {
-			SecretKey Ze = new SecretKeySpec(vector.Ze, "AES");
-			SecretKey Zs = new SecretKeySpec(vector.Zs, "AES");
-			SecretKey Z = ECDH1PU.deriveZ(Ze, Zs);
+    public void test_TestVectors() throws Exception {
+        for (TestVector vector : testVectors) {
+            SecretKey Ze = new SecretKeySpec(vector.Ze, "AES");
+            SecretKey Zs = new SecretKeySpec(vector.Zs, "AES");
+            SecretKey Z = ECDH1PU.deriveZ(Ze, Zs);
 
-			assertArrayEquals(vector.expectedZ, Z.getEncoded());
+            assertArrayEquals(vector.expectedZ, Z.getEncoded());
 
-			JWEHeader jwe = new JWEHeader.Builder(vector.algorithm, vector.encryptionMethod)
-					.agreementPartyUInfo(Base64URL.encode(vector.apu))
-					.agreementPartyVInfo(Base64URL.encode(vector.apv))
-					.build();
+            JWEHeader jwe = new JWEHeader.Builder(vector.algorithm, vector.encryptionMethod)
+                    .agreementPartyUInfo(Base64URL.encode(vector.apu))
+                    .agreementPartyVInfo(Base64URL.encode(vector.apv))
+                    .build();
 
-			if (vector.tag == null) {
-				SecretKey sharedKey = ECDH1PU.deriveSharedKey(jwe, Z, new ConcatKDF("SHA-256"));
-				assertArrayEquals(vector.expectedSharedKey, sharedKey.getEncoded());
-			}
+            if (vector.tag == null) {
+                SecretKey sharedKey = ECDH1PU.deriveSharedKey(jwe, Z, new ConcatKDF("SHA-256"));
+                assertArrayEquals(vector.expectedSharedKey, sharedKey.getEncoded());
+            }
 
-			if (vector.tag != null) {
-				SecretKey sharedKey = ECDH1PU.deriveSharedKey(jwe, Z, vector.tag, new ConcatKDF("SHA-256"));
-				assertArrayEquals(vector.expectedSharedKey, sharedKey.getEncoded());
-			}
-		}
-	}
+            if (vector.tag != null) {
+                SecretKey sharedKey = ECDH1PU.deriveSharedKey(jwe, Z, vector.tag, new ConcatKDF("SHA-256"));
+                assertArrayEquals(vector.expectedSharedKey, sharedKey.getEncoded());
+            }
+        }
+    }
 }

--- a/src/test/java/com/nimbusds/jose/crypto/ECDH1PUX25519CryptoTest.java
+++ b/src/test/java/com/nimbusds/jose/crypto/ECDH1PUX25519CryptoTest.java
@@ -328,7 +328,7 @@ public class ECDH1PUX25519CryptoTest extends TestCase {
     }
 
     // see https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#appendix-B
-    public void test_ECDH_1PU_encryption_decryption() throws Exception {
+    public void test_ECDH_1PU_decryption() throws Exception {
         String exceptedPlaintext = "Three is a magic number.";
         OctetKeyPair aliceKey = OctetKeyPair.parse(
                 "{\"kty\": \"OKP\",\n" +

--- a/src/test/java/com/nimbusds/jose/crypto/ECDH1PUX25519CryptoTest.java
+++ b/src/test/java/com/nimbusds/jose/crypto/ECDH1PUX25519CryptoTest.java
@@ -1,7 +1,7 @@
 /*
  * nimbus-jose-jwt
  *
- * Copyright 2012-2021, Connect2id Ltd.
+ * Copyright 2012-2021, Connect2id Ltd and contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy of the

--- a/src/test/java/com/nimbusds/jose/crypto/ECDH1PUX25519CryptoTest.java
+++ b/src/test/java/com/nimbusds/jose/crypto/ECDH1PUX25519CryptoTest.java
@@ -42,288 +42,288 @@ import java.util.Collections;
 public class ECDH1PUX25519CryptoTest extends TestCase {
 
 
-	private static OctetKeyPair generateOKP(Curve curve) {
+    private static OctetKeyPair generateOKP(Curve curve) {
 
-		try {
-			return new OctetKeyPairGenerator(curve).generate();
-		} catch (JOSEException e) {
-			throw new RuntimeException(e);
-		}
-	}
+        try {
+            return new OctetKeyPairGenerator(curve).generate();
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
-	private static class CycleTest {
-		public Curve curve;
-		public JWEAlgorithm algorithm;
-		public EncryptionMethod encryptionMethod;
+    private static class CycleTest {
+        public Curve curve;
+        public JWEAlgorithm algorithm;
+        public EncryptionMethod encryptionMethod;
 
-		public CycleTest(JWEAlgorithm algorithm, Curve curve, EncryptionMethod encryptionMethod) {
-			this.curve = curve;
-			this.algorithm = algorithm;
-			this.encryptionMethod = encryptionMethod;
-		}
-	}
+        public CycleTest(JWEAlgorithm algorithm, Curve curve, EncryptionMethod encryptionMethod) {
+            this.curve = curve;
+            this.algorithm = algorithm;
+            this.encryptionMethod = encryptionMethod;
+        }
+    }
 
-	private static class CurveTest {
-		public OctetKeyPair aliceKey;
-		public OctetKeyPair bobKey;
-		public OctetKeyPair aliceWrongKey;
-		public OctetKeyPair bobWrongKey;
-		public String expectedMessage;
+    private static class CurveTest {
+        public OctetKeyPair aliceKey;
+        public OctetKeyPair bobKey;
+        public OctetKeyPair aliceWrongKey;
+        public OctetKeyPair bobWrongKey;
+        public String expectedMessage;
 
-		public CurveTest(OctetKeyPair aliceKey,
-						 OctetKeyPair bobKey,
-						 OctetKeyPair aliceWrongKey,
-						 OctetKeyPair bobWrongKey,
-						 String expectedMessage) {
-			this.aliceKey = aliceKey;
-			this.bobKey = bobKey;
-			this.aliceWrongKey = aliceWrongKey;
-			this.bobWrongKey = bobWrongKey;
-			this.expectedMessage = expectedMessage;
-		}
-	}
+        public CurveTest(OctetKeyPair aliceKey,
+                         OctetKeyPair bobKey,
+                         OctetKeyPair aliceWrongKey,
+                         OctetKeyPair bobWrongKey,
+                         String expectedMessage) {
+            this.aliceKey = aliceKey;
+            this.bobKey = bobKey;
+            this.aliceWrongKey = aliceWrongKey;
+            this.bobWrongKey = bobWrongKey;
+            this.expectedMessage = expectedMessage;
+        }
+    }
 
-	private static final CurveTest[] notMatchedCurves = new CurveTest[] {
-			new CurveTest(
-					generateOKP(Curve.X25519),
-					generateOKP(Curve.X25519).toPublicJWK(),
-					generateOKP(Curve.X25519),
-					generateOKP(Curve.X25519),
-					"OKP public key should not be a private key"
-			),
+    private static final CurveTest[] notMatchedCurves = new CurveTest[] {
+            new CurveTest(
+                    generateOKP(Curve.X25519),
+                    generateOKP(Curve.X25519).toPublicJWK(),
+                    generateOKP(Curve.X25519),
+                    generateOKP(Curve.X25519),
+                    "OKP public key should not be a private key"
+            ),
 
-			new CurveTest(
-					generateOKP(Curve.X25519),
-					generateOKP(Curve.X25519).toPublicJWK(),
-					generateOKP(Curve.X25519).toPublicJWK(),
-					generateOKP(Curve.X25519).toPublicJWK(),
-					"OKP private key should be a private key"
-			)
-	};
+            new CurveTest(
+                    generateOKP(Curve.X25519),
+                    generateOKP(Curve.X25519).toPublicJWK(),
+                    generateOKP(Curve.X25519).toPublicJWK(),
+                    generateOKP(Curve.X25519).toPublicJWK(),
+                    "OKP private key should be a private key"
+            )
+    };
 
-	private static final CycleTest[] allowedCycles = new CycleTest[] {
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.X25519, EncryptionMethod.A128CBC_HS256),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.X25519, EncryptionMethod.A192CBC_HS384),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.X25519, EncryptionMethod.A256CBC_HS512),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.X25519, EncryptionMethod.A128GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.X25519, EncryptionMethod.A192GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.X25519, EncryptionMethod.A256GCM),
+    private static final CycleTest[] allowedCycles = new CycleTest[] {
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.X25519, EncryptionMethod.A128CBC_HS256),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.X25519, EncryptionMethod.A192CBC_HS384),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.X25519, EncryptionMethod.A256CBC_HS512),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.X25519, EncryptionMethod.A128GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.X25519, EncryptionMethod.A192GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU, Curve.X25519, EncryptionMethod.A256GCM),
 
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.X25519, EncryptionMethod.A128CBC_HS256),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.X25519, EncryptionMethod.A192CBC_HS384),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.X25519, EncryptionMethod.A256CBC_HS512),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.X25519, EncryptionMethod.A128CBC_HS256),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.X25519, EncryptionMethod.A192CBC_HS384),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.X25519, EncryptionMethod.A256CBC_HS512),
 
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.X25519, EncryptionMethod.A128CBC_HS256),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.X25519, EncryptionMethod.A192CBC_HS384),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.X25519, EncryptionMethod.A256CBC_HS512),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.X25519, EncryptionMethod.A128CBC_HS256),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.X25519, EncryptionMethod.A192CBC_HS384),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.X25519, EncryptionMethod.A256CBC_HS512),
 
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.X25519, EncryptionMethod.A128CBC_HS256),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.X25519, EncryptionMethod.A192CBC_HS384),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.X25519, EncryptionMethod.A256CBC_HS512)
-	};
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.X25519, EncryptionMethod.A128CBC_HS256),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.X25519, EncryptionMethod.A192CBC_HS384),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.X25519, EncryptionMethod.A256CBC_HS512)
+    };
 
-	private static final CycleTest[] forbiddenCycles = new CycleTest[] {
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.X25519, EncryptionMethod.A128GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.X25519, EncryptionMethod.A192GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.X25519, EncryptionMethod.A256GCM),
+    private static final CycleTest[] forbiddenCycles = new CycleTest[] {
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.X25519, EncryptionMethod.A128GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.X25519, EncryptionMethod.A192GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A128KW, Curve.X25519, EncryptionMethod.A256GCM),
 
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.X25519, EncryptionMethod.A128GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.X25519, EncryptionMethod.A192GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.X25519, EncryptionMethod.A256GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.X25519, EncryptionMethod.A128GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.X25519, EncryptionMethod.A192GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A192KW, Curve.X25519, EncryptionMethod.A256GCM),
 
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.X25519, EncryptionMethod.A128GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.X25519, EncryptionMethod.A192GCM),
-			new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.X25519, EncryptionMethod.A256GCM),
-	};
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.X25519, EncryptionMethod.A128GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.X25519, EncryptionMethod.A192GCM),
+            new CycleTest(JWEAlgorithm.ECDH_1PU_A256KW, Curve.X25519, EncryptionMethod.A256GCM),
+    };
 
-	public void testCycle() throws Exception {
-		Payload payload = new Payload("Hello world!");
+    public void testCycle() throws Exception {
+        Payload payload = new Payload("Hello world!");
 
-		for (CycleTest cycle : allowedCycles) {
-			OctetKeyPair aliceKey = generateOKP(cycle.curve);
-			OctetKeyPair bobKey = generateOKP(cycle.curve);
+        for (CycleTest cycle : allowedCycles) {
+            OctetKeyPair aliceKey = generateOKP(cycle.curve);
+            OctetKeyPair bobKey = generateOKP(cycle.curve);
 
-			JWEHeader header = new JWEHeader.Builder(cycle.algorithm, cycle.encryptionMethod).
-					agreementPartyUInfo(Base64URL.encode("Alice")).
-					agreementPartyVInfo(Base64URL.encode("Bob")).
-					build();
+            JWEHeader header = new JWEHeader.Builder(cycle.algorithm, cycle.encryptionMethod).
+                    agreementPartyUInfo(Base64URL.encode("Alice")).
+                    agreementPartyVInfo(Base64URL.encode("Bob")).
+                    build();
 
-			JWEObject jweObject = new JWEObject(header, payload);
+            JWEObject jweObject = new JWEObject(header, payload);
 
-			ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceKey, bobKey.toPublicJWK());
-			encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
-			jweObject.encrypt(encrypter);
+            ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceKey, bobKey.toPublicJWK());
+            encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+            jweObject.encrypt(encrypter);
 
-			OctetKeyPair epk = (OctetKeyPair) jweObject.getHeader().getEphemeralPublicKey();
-			assertEquals(cycle.curve, epk.getCurve());
-			assertNotNull(epk.getX());
-			assertNull(epk.getD());
+            OctetKeyPair epk = (OctetKeyPair) jweObject.getHeader().getEphemeralPublicKey();
+            assertEquals(cycle.curve, epk.getCurve());
+            assertNotNull(epk.getX());
+            assertNull(epk.getD());
 
-			String jwe = jweObject.serialize();
-			jweObject = JWEObject.parse(jwe);
+            String jwe = jweObject.serialize();
+            jweObject = JWEObject.parse(jwe);
 
-			ECDH1PUX25519Decrypter decrypter = new ECDH1PUX25519Decrypter(bobKey, aliceKey.toPublicJWK());
-			decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
-			jweObject.decrypt(decrypter);
+            ECDH1PUX25519Decrypter decrypter = new ECDH1PUX25519Decrypter(bobKey, aliceKey.toPublicJWK());
+            decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+            jweObject.decrypt(decrypter);
 
-			assertEquals(payload.toString(), jweObject.getPayload().toString());
-		}
-	}
+            assertEquals(payload.toString(), jweObject.getPayload().toString());
+        }
+    }
 
-	public void testCycle_isForbidden() {
-		Payload payload = new Payload("Hello world!");
+    public void testCycle_isForbidden() {
+        Payload payload = new Payload("Hello world!");
 
-		for (CycleTest cycle : forbiddenCycles) {
-			OctetKeyPair aliceKey = generateOKP(cycle.curve);
-			OctetKeyPair bobKey = generateOKP(cycle.curve);
+        for (CycleTest cycle : forbiddenCycles) {
+            OctetKeyPair aliceKey = generateOKP(cycle.curve);
+            OctetKeyPair bobKey = generateOKP(cycle.curve);
 
-			JWEHeader header = new JWEHeader.Builder(cycle.algorithm, cycle.encryptionMethod).
-					agreementPartyUInfo(Base64URL.encode("Alice")).
-					agreementPartyVInfo(Base64URL.encode("Bob")).
-					build();
+            JWEHeader header = new JWEHeader.Builder(cycle.algorithm, cycle.encryptionMethod).
+                    agreementPartyUInfo(Base64URL.encode("Alice")).
+                    agreementPartyVInfo(Base64URL.encode("Bob")).
+                    build();
 
-			JWEObject jweObject = new JWEObject(header, payload);
+            JWEObject jweObject = new JWEObject(header, payload);
 
-			try {
-				ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceKey, bobKey.toPublicJWK());
-				encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
-				jweObject.encrypt(encrypter);
-				fail();
-			} catch (JOSEException e) {
-				String expectedMessage = String.format("Unsupported JWE encryption method %s, " +
-								"must be A128CBC-HS256, A192CBC-HS384 or A256CBC-HS512",
-						cycle.encryptionMethod.getName());
-				assertEquals(expectedMessage, e.getMessage());
-			}
-		}
-	}
+            try {
+                ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceKey, bobKey.toPublicJWK());
+                encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+                jweObject.encrypt(encrypter);
+                fail();
+            } catch (JOSEException e) {
+                String expectedMessage = String.format("Unsupported JWE encryption method %s, " +
+                                "must be A128CBC-HS256, A192CBC-HS384 or A256CBC-HS512",
+                        cycle.encryptionMethod.getName());
+                assertEquals(expectedMessage, e.getMessage());
+            }
+        }
+    }
 
-	public void testCycle_WithCekSpecified() throws Exception {
-		Payload payload = new Payload("Hello world!");
+    public void testCycle_WithCekSpecified() throws Exception {
+        Payload payload = new Payload("Hello world!");
 
-		for (CycleTest cycle : allowedCycles) {
-			if (cycle.encryptionMethod.cekBitLength() == 0)
-				continue;
+        for (CycleTest cycle : allowedCycles) {
+            if (cycle.encryptionMethod.cekBitLength() == 0)
+                continue;
 
-			SecretKey cek = ContentCryptoProvider.generateCEK(cycle.encryptionMethod, new SecureRandom());
+            SecretKey cek = ContentCryptoProvider.generateCEK(cycle.encryptionMethod, new SecureRandom());
 
-			OctetKeyPair aliceKey = generateOKP(cycle.curve);
-			OctetKeyPair bobKey = generateOKP(cycle.curve);
+            OctetKeyPair aliceKey = generateOKP(cycle.curve);
+            OctetKeyPair bobKey = generateOKP(cycle.curve);
 
-			JWEHeader header = new JWEHeader.Builder(cycle.algorithm, cycle.encryptionMethod).
-					agreementPartyUInfo(Base64URL.encode("Alice")).
-					agreementPartyVInfo(Base64URL.encode("Bob")).
-					build();
+            JWEHeader header = new JWEHeader.Builder(cycle.algorithm, cycle.encryptionMethod).
+                    agreementPartyUInfo(Base64URL.encode("Alice")).
+                    agreementPartyVInfo(Base64URL.encode("Bob")).
+                    build();
 
-			JWEObject jweObject = new JWEObject(header, payload);
+            JWEObject jweObject = new JWEObject(header, payload);
 
-			ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceKey, bobKey.toPublicJWK(), cek);
-			encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
-			jweObject.encrypt(encrypter);
+            ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceKey, bobKey.toPublicJWK(), cek);
+            encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+            jweObject.encrypt(encrypter);
 
-			OctetKeyPair epk = (OctetKeyPair) jweObject.getHeader().getEphemeralPublicKey();
-			assertEquals(cycle.curve, epk.getCurve());
-			assertNotNull(epk.getX());
-			assertNull(epk.getD());
+            OctetKeyPair epk = (OctetKeyPair) jweObject.getHeader().getEphemeralPublicKey();
+            assertEquals(cycle.curve, epk.getCurve());
+            assertNotNull(epk.getX());
+            assertNull(epk.getD());
 
-			String jwe = jweObject.serialize();
-			jweObject = JWEObject.parse(jwe);
+            String jwe = jweObject.serialize();
+            jweObject = JWEObject.parse(jwe);
 
-			ECDH1PUX25519Decrypter decrypter = new ECDH1PUX25519Decrypter(bobKey, aliceKey.toPublicJWK());
-			decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
-			jweObject.decrypt(decrypter);
+            ECDH1PUX25519Decrypter decrypter = new ECDH1PUX25519Decrypter(bobKey, aliceKey.toPublicJWK());
+            decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+            jweObject.decrypt(decrypter);
 
-			assertEquals(payload.toString(), jweObject.getPayload().toString());
-		}
-	}
+            assertEquals(payload.toString(), jweObject.getPayload().toString());
+        }
+    }
 
-	public void testCritParamDeferral()
-		throws Exception {
+    public void testCritParamDeferral()
+        throws Exception {
 
-		OctetKeyPair aliceKey = generateOKP(Curve.X25519);
-		OctetKeyPair bobKey = generateOKP(Curve.X25519);
+        OctetKeyPair aliceKey = generateOKP(Curve.X25519);
+        OctetKeyPair bobKey = generateOKP(Curve.X25519);
 
-		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128CBC_HS256).
-			customParam(JWTClaimNames.EXPIRATION_TIME, "2014-04-24").
-			criticalParams(Collections.singleton(JWTClaimNames.EXPIRATION_TIME)).
-			build();
+        JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128CBC_HS256).
+            customParam(JWTClaimNames.EXPIRATION_TIME, "2014-04-24").
+            criticalParams(Collections.singleton(JWTClaimNames.EXPIRATION_TIME)).
+            build();
 
-		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
-		ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceKey, bobKey.toPublicJWK());
-		jweObject.encrypt(encrypter);
+        JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+        ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceKey, bobKey.toPublicJWK());
+        jweObject.encrypt(encrypter);
 
-		jweObject = JWEObject.parse(jweObject.serialize());
-		ECDH1PUX25519Decrypter decrypter = new ECDH1PUX25519Decrypter(bobKey, aliceKey.toPublicJWK(), Collections.singleton(JWTClaimNames.EXPIRATION_TIME));
-		jweObject.decrypt(decrypter);
+        jweObject = JWEObject.parse(jweObject.serialize());
+        ECDH1PUX25519Decrypter decrypter = new ECDH1PUX25519Decrypter(bobKey, aliceKey.toPublicJWK(), Collections.singleton(JWTClaimNames.EXPIRATION_TIME));
+        jweObject.decrypt(decrypter);
 
-		assertEquals("Hello world!", jweObject.getPayload().toString());
-	}
+        assertEquals("Hello world!", jweObject.getPayload().toString());
+    }
 
 
-	public void testCritParamReject()
-		throws Exception {
+    public void testCritParamReject()
+        throws Exception {
 
-		OctetKeyPair aliceKey = generateOKP(Curve.X25519);
-		OctetKeyPair bobKey = generateOKP(Curve.X25519);
+        OctetKeyPair aliceKey = generateOKP(Curve.X25519);
+        OctetKeyPair bobKey = generateOKP(Curve.X25519);
 
-		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128CBC_HS256).
-			customParam(JWTClaimNames.EXPIRATION_TIME, "2014-04-24").
-			criticalParams(Collections.singleton(JWTClaimNames.EXPIRATION_TIME)).
-			build();
+        JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128CBC_HS256).
+            customParam(JWTClaimNames.EXPIRATION_TIME, "2014-04-24").
+            criticalParams(Collections.singleton(JWTClaimNames.EXPIRATION_TIME)).
+            build();
 
-		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
-		ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceKey, bobKey.toPublicJWK());
-		jweObject.encrypt(encrypter);
+        JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+        ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceKey, bobKey.toPublicJWK());
+        jweObject.encrypt(encrypter);
 
-		jweObject = JWEObject.parse(jweObject.serialize());
+        jweObject = JWEObject.parse(jweObject.serialize());
 
-		try {
-			ECDH1PUX25519Decrypter decrypter = new ECDH1PUX25519Decrypter(bobKey, aliceKey.toPublicJWK());
-			jweObject.decrypt(decrypter);
-			fail();
-		} catch (JOSEException e) {
-			// ok
-			assertEquals("Unsupported critical header parameter(s)", e.getMessage());
-		}
-	}
+        try {
+            ECDH1PUX25519Decrypter decrypter = new ECDH1PUX25519Decrypter(bobKey, aliceKey.toPublicJWK());
+            jweObject.decrypt(decrypter);
+            fail();
+        } catch (JOSEException e) {
+            // ok
+            assertEquals("Unsupported critical header parameter(s)", e.getMessage());
+        }
+    }
 
-	public void testCurveNotMatch() throws Exception {
-		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128CBC_HS256).
-				customParam(JWTClaimNames.EXPIRATION_TIME, "2014-04-24").
-				criticalParams(Collections.singleton(JWTClaimNames.EXPIRATION_TIME)).
-				build();
+    public void testCurveNotMatch() throws Exception {
+        JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128CBC_HS256).
+                customParam(JWTClaimNames.EXPIRATION_TIME, "2014-04-24").
+                criticalParams(Collections.singleton(JWTClaimNames.EXPIRATION_TIME)).
+                build();
 
-		for (CurveTest curveTest : notMatchedCurves) {
-			try {
-				OctetKeyPair aliceOKPKey = curveTest.aliceWrongKey;
-				OctetKeyPair bobOKPKey = curveTest.bobWrongKey;
+        for (CurveTest curveTest : notMatchedCurves) {
+            try {
+                OctetKeyPair aliceOKPKey = curveTest.aliceWrongKey;
+                OctetKeyPair bobOKPKey = curveTest.bobWrongKey;
 
-				JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
-				ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceOKPKey, bobOKPKey);
-				jweObject.encrypt(encrypter);
+                JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+                ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceOKPKey, bobOKPKey);
+                jweObject.encrypt(encrypter);
 
-				fail();
-			} catch (JOSEException e) {
-				assertEquals(curveTest.expectedMessage, e.getMessage());
-			}
-		}
+                fail();
+            } catch (JOSEException e) {
+                assertEquals(curveTest.expectedMessage, e.getMessage());
+            }
+        }
 
-		for (CurveTest curveTest : notMatchedCurves) {
-			OctetKeyPair aliceOKPKey = curveTest.aliceKey;
-			OctetKeyPair bobOKPKey = curveTest.bobKey;
+        for (CurveTest curveTest : notMatchedCurves) {
+            OctetKeyPair aliceOKPKey = curveTest.aliceKey;
+            OctetKeyPair bobOKPKey = curveTest.bobKey;
 
-			JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
-			ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceOKPKey, bobOKPKey);
-			jweObject.encrypt(encrypter);
+            JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+            ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceOKPKey, bobOKPKey);
+            jweObject.encrypt(encrypter);
 
-			try {
-				ECDH1PUX25519Decrypter decrypter = new ECDH1PUX25519Decrypter(curveTest.aliceWrongKey, curveTest.bobWrongKey);
-				decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
-				jweObject.decrypt(decrypter);
-				fail();
-			} catch (JOSEException e) {
-				assertEquals(curveTest.expectedMessage, e.getMessage());
-			}
-		}
-	}
+            try {
+                ECDH1PUX25519Decrypter decrypter = new ECDH1PUX25519Decrypter(curveTest.aliceWrongKey, curveTest.bobWrongKey);
+                decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+                jweObject.decrypt(decrypter);
+                fail();
+            } catch (JOSEException e) {
+                assertEquals(curveTest.expectedMessage, e.getMessage());
+            }
+        }
+    }
 }

--- a/src/test/java/com/nimbusds/jose/crypto/ECDH1PUX25519CryptoTest.java
+++ b/src/test/java/com/nimbusds/jose/crypto/ECDH1PUX25519CryptoTest.java
@@ -30,7 +30,6 @@ import junit.framework.TestCase;
 
 import javax.crypto.SecretKey;
 import java.security.SecureRandom;
-import java.text.ParseException;
 import java.util.Collections;
 
 

--- a/src/test/java/com/nimbusds/jose/crypto/ECDH1PUX25519CryptoTest.java
+++ b/src/test/java/com/nimbusds/jose/crypto/ECDH1PUX25519CryptoTest.java
@@ -342,6 +342,12 @@ public class ECDH1PUX25519CryptoTest extends TestCase {
                         " \"x\": \"BT7aR0ItXfeDAldeeOlXL_wXqp-j5FltT0vRSG16kRw\",\n" +
                         " \"d\": \"1gDirl_r_Y3-qUa3WXHgEXrrEHngWThU3c9zj9A2uBg\"}");
 
+        OctetKeyPair charlieKey = OctetKeyPair.parse(
+                "{\"kty\": \"OKP\",\n" +
+                        " \"crv\": \"X25519\",\n" +
+                        " \"x\": \"BT7aR0ItXfeDAldeeOlXL_wXqp-j5FltT0vRSG16kRw\",\n" +
+                        " \"d\": \"1gDirl_r_Y3-qUa3WXHgEXrrEHngWThU3c9zj9A2uBg\"}");
+
         JWEObject jweObject = new JWEObject(
                 Base64URL.from("eyJhbGciOiJFQ0RILTFQVStBMTI4S1ciLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwiYXB1Ijoi" +
                         "UVd4cFkyVSIsImFwdiI6IlFtOWlJR0Z1WkNCRGFHRnliR2xsIiwiZXBrIjp7Imt0eSI6Ik9L" +
@@ -353,9 +359,26 @@ public class ECDH1PUX25519CryptoTest extends TestCase {
                 Base64URL.from("HLb4fTlm8spGmij3RyOs2gJ4DpHM4hhVRwdF_hGb3WQ")
         );
 
-        ECDH1PUX25519Decrypter decrypter = new ECDH1PUX25519Decrypter(bobKey, aliceKey.toPublicJWK());
-        jweObject.decrypt(decrypter);
+        String jwe = jweObject.serialize();
 
-        assertEquals(exceptedPlaintext, jweObject.getPayload().toString());
+        // Bob can decrypt message
+        JWEObject bobMessage = JWEObject.parse(jwe);
+        ECDH1PUX25519Decrypter bobDecrypter = new ECDH1PUX25519Decrypter(
+                bobKey,
+                aliceKey.toPublicJWK()
+        );
+
+        bobMessage.decrypt(bobDecrypter);
+        assertEquals(exceptedPlaintext, bobMessage.getPayload().toString());
+
+        // Charlie can decrypt message
+        JWEObject charlieMessage = JWEObject.parse(jwe);
+        ECDH1PUX25519Decrypter charlieDecrypter = new ECDH1PUX25519Decrypter(
+                charlieKey,
+                aliceKey.toPublicJWK()
+        );
+
+        charlieMessage.decrypt(charlieDecrypter);
+        assertEquals(exceptedPlaintext, charlieMessage.getPayload().toString());
     }
 }

--- a/src/test/java/com/nimbusds/jose/crypto/ECDH1PUX25519CryptoTest.java
+++ b/src/test/java/com/nimbusds/jose/crypto/ECDH1PUX25519CryptoTest.java
@@ -1,0 +1,170 @@
+/*
+ * nimbus-jose-jwt
+ *
+ * Copyright 2012-2018, Connect2id Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.nimbusds.jose.crypto;
+
+
+import com.google.crypto.tink.subtle.X25519;
+import com.nimbusds.jose.*;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.OctetKeyPair;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimNames;
+import junit.framework.TestCase;
+
+import java.util.Collections;
+
+
+/**
+ * Tests X25519 ECDH-1PU encryption and decryption.
+ *
+ * @author Alexander Martynov
+ * @version 2021-08-04
+ */
+public class ECDH1PUX25519CryptoTest extends TestCase {
+
+
+	private static OctetKeyPair generateOKP()
+		throws Exception {
+
+		byte[] privateKey = X25519.generatePrivateKey();
+		byte[] publicKey = X25519.publicFromPrivate(privateKey);
+
+		return new OctetKeyPair.Builder(Curve.X25519, Base64URL.encode(publicKey)).
+			d(Base64URL.encode(privateKey)).
+			build();
+	}
+
+
+	public void testCycle_ECDH_1PU_X25519()
+		throws Exception {
+
+		OctetKeyPair aliceKey = generateOKP();
+		OctetKeyPair bobKey = generateOKP();
+
+		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128GCM).
+			agreementPartyUInfo(Base64URL.encode("Alice")).
+			agreementPartyVInfo(Base64URL.encode("Bob")).
+			build();
+
+		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+
+		ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceKey, bobKey.toPublicJWK());
+		jweObject.encrypt(encrypter);
+
+		OctetKeyPair epk = (OctetKeyPair) jweObject.getHeader().getEphemeralPublicKey();
+		assertEquals(Curve.X25519, epk.getCurve());
+		assertNotNull(epk.getX());
+		assertNull(epk.getD());
+
+		assertNull(jweObject.getEncryptedKey());
+
+		String jwe = jweObject.serialize();
+
+		jweObject = JWEObject.parse(jwe);
+
+		ECDH1PUX25519Decrypter decrypter = new ECDH1PUX25519Decrypter(bobKey, aliceKey.toPublicJWK());
+		jweObject.decrypt(decrypter);
+
+		assertEquals("Hello world!", jweObject.getPayload().toString());
+	}
+
+
+	public void testCycle_ECDH_1PU_X25519_A128KW()
+		throws Exception {
+
+		OctetKeyPair aliceKey = generateOKP();
+		OctetKeyPair bobKey = generateOKP();
+
+		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU_A128KW, EncryptionMethod.A128GCM).
+			agreementPartyUInfo(Base64URL.encode("Alice")).
+			agreementPartyVInfo(Base64URL.encode("Bob")).
+			build();
+
+		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+
+		ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceKey, bobKey.toPublicJWK());
+		jweObject.encrypt(encrypter);
+
+		OctetKeyPair epk = (OctetKeyPair) jweObject.getHeader().getEphemeralPublicKey();
+		assertEquals(Curve.X25519, epk.getCurve());
+		assertNotNull(epk.getX());
+		assertNull(epk.getD());
+
+		assertNotNull(jweObject.getEncryptedKey());
+
+		String jwe = jweObject.serialize();
+
+		jweObject = JWEObject.parse(jwe);
+
+		ECDH1PUX25519Decrypter decrypter = new ECDH1PUX25519Decrypter(bobKey, aliceKey.toPublicJWK());
+		jweObject.decrypt(decrypter);
+
+		assertEquals("Hello world!", jweObject.getPayload().toString());
+	}
+
+
+	public void testCritParamDeferral()
+		throws Exception {
+
+		OctetKeyPair aliceKey = generateOKP();
+		OctetKeyPair bobKey = generateOKP();
+
+		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128CBC_HS256).
+			customParam(JWTClaimNames.EXPIRATION_TIME, "2014-04-24").
+			criticalParams(Collections.singleton(JWTClaimNames.EXPIRATION_TIME)).
+			build();
+
+		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+		ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceKey, bobKey.toPublicJWK());
+		jweObject.encrypt(encrypter);
+
+		jweObject = JWEObject.parse(jweObject.serialize());
+		ECDH1PUX25519Decrypter decrypter = new ECDH1PUX25519Decrypter(bobKey, aliceKey.toPublicJWK(), Collections.singleton(JWTClaimNames.EXPIRATION_TIME));
+		jweObject.decrypt(decrypter);
+
+		assertEquals("Hello world!", jweObject.getPayload().toString());
+	}
+
+
+	public void testCritParamReject()
+		throws Exception {
+
+		OctetKeyPair aliceKey = generateOKP();
+		OctetKeyPair bobKey = generateOKP();
+
+		JWEHeader header = new JWEHeader.Builder(JWEAlgorithm.ECDH_1PU, EncryptionMethod.A128CBC_HS256).
+			customParam(JWTClaimNames.EXPIRATION_TIME, "2014-04-24").
+			criticalParams(Collections.singleton(JWTClaimNames.EXPIRATION_TIME)).
+			build();
+
+		JWEObject jweObject = new JWEObject(header, new Payload("Hello world!"));
+		ECDH1PUX25519Encrypter encrypter = new ECDH1PUX25519Encrypter(aliceKey, bobKey.toPublicJWK());
+		jweObject.encrypt(encrypter);
+
+		jweObject = JWEObject.parse(jweObject.serialize());
+
+		try {
+			ECDH1PUX25519Decrypter decrypter = new ECDH1PUX25519Decrypter(bobKey, aliceKey.toPublicJWK());
+			jweObject.decrypt(decrypter);
+			fail();
+		} catch (JOSEException e) {
+			// ok
+			assertEquals("Unsupported critical header parameter(s)", e.getMessage());
+		}
+	}
+}

--- a/src/test/java/com/nimbusds/jose/crypto/impl/ConcatKDFTest.java
+++ b/src/test/java/com/nimbusds/jose/crypto/impl/ConcatKDFTest.java
@@ -25,6 +25,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 import com.nimbusds.jose.crypto.impl.ConcatKDF;
+import com.nimbusds.jose.util.Base64;
 import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jose.util.ByteUtils;
 import com.nimbusds.jose.util.IntegerUtils;
@@ -65,7 +66,42 @@ public class ConcatKDFTest extends TestCase {
 		
 		assertTrue(Arrays.equals(expected, otherInfo));
 	}
-	
+
+	public void testComposeOtherInfoWithTag() {
+
+		// From https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#appendix-B.9
+
+		String algId = "ECDH-1PU+A128KW";
+		Base64URL tag = Base64URL.from("HLb4fTlm8spGmij3RyOs2gJ4DpHM4hhVRwdF_hGb3WQ");
+		String producer = "Alice";
+		String consumer = "Bob and Charlie";
+		int pubInfo = 128;
+
+		byte[] otherInfo = ConcatKDF.composeOtherInfo(
+				ConcatKDF.encodeStringData(algId),
+				ConcatKDF.encodeStringData(producer),
+				ConcatKDF.encodeStringData(consumer),
+				ConcatKDF.encodeIntData(pubInfo),
+				ConcatKDF.encodeNoData(),
+				ConcatKDF.encodeDataWithLength(tag));
+
+		byte[] expected = {
+				(byte) 0, (byte) 0, (byte) 0, (byte) 15, (byte) 69, (byte) 67, (byte) 68, (byte) 72,
+				(byte) 45, (byte) 49, (byte) 80, (byte) 85, (byte) 43, (byte) 65, (byte) 49, (byte) 50,
+				(byte) 56, (byte) 75, (byte) 87, (byte) 0, (byte) 0, (byte) 0, (byte) 5, (byte) 65,
+				(byte) 108, (byte) 105, (byte) 99, (byte) 101, (byte) 0, (byte) 0, (byte) 0, (byte) 15,
+				(byte) 66, (byte) 111, (byte) 98, (byte) 32, (byte) 97, (byte) 110, (byte) 100,
+				(byte) 32, (byte) 67, (byte) 104, (byte) 97, (byte) 114, (byte) 108, (byte) 105,
+				(byte) 101, (byte) 0, (byte) 0, (byte) 0, (byte) -128, (byte) 0, (byte) 0, (byte) 0,
+				(byte) 32, (byte) 28, (byte) -74, (byte) -8, (byte) 125, (byte) 57, (byte) 102,
+				(byte) -14, (byte) -54, (byte) 70, (byte) -102, (byte) 40, (byte) -9, (byte) 71,
+				(byte) 35, (byte) -84, (byte) -38, (byte) 2, (byte) 120, (byte) 14, (byte) -111,
+				(byte) -52, (byte) -30, (byte) 24, (byte) 85, (byte) 71, (byte) 7, (byte) 69,
+				(byte) -2, (byte) 17, (byte) -101, (byte) -35, (byte) 100
+		};
+
+		assertTrue(Arrays.equals(expected, otherInfo));
+	}
 	
 	public void testECDHVector()
 		throws Exception {


### PR DESCRIPTION
* Added support ECDH-1PU draft4
* Added support the following key management algorithms for ECDH-1PU:
   - ECDH_1PU
   - ECDH_1PU_A128KW
   - ECDH_1PU_A192KW
   - ECDH_1PU_A256KW
* Supports the following elliptic curves for ECDH-1PU:
   - P_256
   - P_384
   - P_521
   - Curve25519/X25519
* Unit tests for ECDH-1PU